### PR TITLE
Add adc_hpf() to allow control of ADC high pass filter.

### DIFF
--- a/control_sgtl5000.cpp
+++ b/control_sgtl5000.cpp
@@ -622,6 +622,17 @@ unsigned short AudioControlSGTL5000::dac_vol(float left, float right)
 	return modify(CHIP_DAC_VOL,m,65535);
 }
 
+unsigned short AudioControlSGTL5000::adc_hpf(uint8_t bypass, uint8_t freeze)
+{
+	return modify(CHIP_ADCDAC_CTRL, (freeze&1)<<1|bypass&1,3);
+}
+
+unsigned short AudioControlSGTL5000::adc_hpf(uint8_t bypass)
+{
+	return modify(CHIP_ADCDAC_CTRL, bypass&1,1);
+}
+
+
 // DAP_CONTROL
 unsigned short AudioControlSGTL5000::dap_mix_enable(uint8_t n)
 {

--- a/control_sgtl5000.h
+++ b/control_sgtl5000.h
@@ -59,6 +59,8 @@ public:
 	unsigned short lo_lvl(uint8_t left, uint8_t right);
 	unsigned short dac_vol(float n);
 	unsigned short dac_vol(float left, float right);
+	unsigned short adc_hpf(uint8_t bypass, uint8_t freeze);
+	unsigned short adc_hpf(uint8_t bypass);
 	unsigned short dap_mix_enable(uint8_t n);
 	unsigned short dap_enable(uint8_t n);
 	unsigned short dap_enable(void);


### PR DESCRIPTION
A little thing, was remiss of me not to include it earlier.

unsigned short .adc_hpf(uint8_t bypass, uint8_t freeze);
unsigned short .adc_hpf(uint8_t bypass);
bypass & freeze as defined on page 34 of the SGTL5000 datasheet.
