### PR TITLE
BUG: Small error in linear interpolation

### DIFF
--- a/synth_sine.cpp
+++ b/synth_sine.cpp
@@ -50,7 +50,7 @@ void AudioSynthWaveformSine::update(void)
 				val2 = AudioWaveformSine[index+1];
 				scale = (ph >> 8) & 0xFFFF;
 				val2 *= scale;
-				val1 *= 0xFFFF - scale;
+				val1 *= 0x10000 - scale;
 				//block->data[i] = (((val1 + val2) >> 16) * magnitude) >> 16;
 				block->data[i] = multiply_32x32_rshift32(val1 + val2, magnitude);
 				ph += inc;
@@ -98,7 +98,7 @@ void AudioSynthWaveformSineModulated::update(void)
 			val2 = AudioWaveformSine[index+1];
 			scale = (ph >> 8) & 0xFFFF;
 			val2 *= scale;
-			val1 *= 0xFFFF - scale;
+			val1 *= 0x10000 - scale;
 			//block->data[i] = (((val1 + val2) >> 16) * magnitude) >> 16;
 			block->data[i] = multiply_32x32_rshift32(val1 + val2, magnitude);
 			// -32768 = no phase increment
@@ -117,7 +117,7 @@ void AudioSynthWaveformSineModulated::update(void)
 			val2 = AudioWaveformSine[index+1];
 			scale = (ph >> 8) & 0xFFFF;
 			val2 *= scale;
-			val1 *= 0xFFFF - scale;
+			val1 *= 0x10000 - scale;
 			block->data[i] = (val1 + val2) >> 16;
 			ph += inc;
 		}


### PR DESCRIPTION
This is from https://forum.pjrc.com/threads/27608-Very-minor-mistake-in-Audio-synth_sine-cpp

I haven't verified that it's correct myself.

Also see https://github.com/endolith/Audio/commit/210516665c394a836e76c79a4cce88daa2baecf6 where I combined these into a function (to make it easier to create new additive synthesis functions).  I can submit that too if it's a desirable change.