### PR TITLE
added mute_PCM() - sets or unsets VALID in VUCP (and adjusts PARITY)

### DIFF
--- a/output_spdif.cpp
+++ b/output_spdif.cpp
@@ -21,7 +21,16 @@
  * THE SOFTWARE.
  */
 
+ // 2015/08/23: (FB) added mute_PCM() - sets or unsets VALID in VUCP (and adjusts PARITY)
+ 
 #include "output_spdif.h"
+
+#define PREAMBLE_B  (0xE8) //11101000
+#define PREAMBLE_M  (0xE2) //11100010
+#define PREAMBLE_W  (0xE4) //11100100
+
+#define VUCP_VALID   ((0xCC) << 24)
+#define VUCP_INVALID ((0xD4) << 24)// To mute PCM, set VUCP = invalid.
 
 audio_block_t * AudioOutputSPDIF::block_left_1st = NULL;
 audio_block_t * AudioOutputSPDIF::block_right_1st = NULL;
@@ -30,6 +39,7 @@ audio_block_t * AudioOutputSPDIF::block_right_2nd = NULL;
 uint16_t  AudioOutputSPDIF::block_left_offset = 0;
 uint16_t  AudioOutputSPDIF::block_right_offset = 0;
 bool AudioOutputSPDIF::update_responsibility = false;
+uint32_t  AudioOutputSPDIF::vucp = VUCP_VALID;
 
 DMAMEM static uint32_t SPDIF_tx_buffer[AUDIO_BLOCK_SAMPLES * 4]; //2 KB
 
@@ -71,13 +81,10 @@ uint16_t bmclookup[256] = { //biphase mark encoded values (least significant bit
 	0x32aa, 0xb2aa, 0xd2aa, 0x52aa, 0xcaaa, 0x4aaa, 0x2aaa, 0xaaaa
 };
 
-#define PREAMBLE_B  (0xE8) //11101000
-#define PREAMBLE_M  (0xE2) //11100010
-#define PREAMBLE_W  (0xE4) //11100100
 
 void AudioOutputSPDIF::begin(void)
 {
-
+    
 	dma.begin(true); // Allocate the DMA channel first
 
 	block_left_1st = NULL;
@@ -165,10 +172,10 @@ void AudioOutputSPDIF::isr(void)
 
 			if (++frame > 191) {
 				// VUCP-Bits ("Valid, Subcode, Channelstatus, Parity) = 0 (0xcc) | Preamble (depends on Framno.) | Auxillary
-				*(dest+0) = 0xcc000000 | (PREAMBLE_B << 16 ) | aux; //special preamble for one of 192 frames
+				*(dest+0) =  vucp | (PREAMBLE_B << 16 ) | aux; //special preamble for one of 192 frames								
 				frame = 0;
 			} else {
-				*(dest+0) = 0xcc000000 | (PREAMBLE_M << 16 ) | aux;
+				*(dest+0) = vucp | (PREAMBLE_M << 16 ) | aux;
 			}
 			dest += 4;
 
@@ -214,7 +221,7 @@ void AudioOutputSPDIF::isr(void)
 			*(dest+1) = ( ((uint32_t)lo << 16) | hi );
 
 			aux = (0xB333 ^ (((uint32_t)((int16_t)lo)) >> 17));
-			*(dest+0)  =  0xcc000000 | (PREAMBLE_W << 16 ) | aux;
+			*(dest+0)  =  vucp | (PREAMBLE_W << 16 ) | aux;
 
 			dest += 4;
 		} while (dest < end);
@@ -236,6 +243,11 @@ void AudioOutputSPDIF::isr(void)
 		} while (dest < end);
 	}
 
+}
+
+void AudioOutputSPDIF::mute_PCM(const bool mute)
+{
+	vucp = mute?VUCP_INVALID:VUCP_VALID;		
 }
 
 void AudioOutputSPDIF::update(void)

--- a/output_spdif.cpp
+++ b/output_spdif.cpp
@@ -22,7 +22,7 @@
  */
 
  // 2015/08/23: (FB) added mute_PCM() - sets or unsets VALID in VUCP (and adjusts PARITY)
- 
+
 #include "output_spdif.h"
 
 #define PREAMBLE_B  (0xE8) //11101000
@@ -84,7 +84,7 @@ uint16_t bmclookup[256] = { //biphase mark encoded values (least significant bit
 
 void AudioOutputSPDIF::begin(void)
 {
-    
+
 	dma.begin(true); // Allocate the DMA channel first
 
 	block_left_1st = NULL;
@@ -172,7 +172,7 @@ void AudioOutputSPDIF::isr(void)
 
 			if (++frame > 191) {
 				// VUCP-Bits ("Valid, Subcode, Channelstatus, Parity) = 0 (0xcc) | Preamble (depends on Framno.) | Auxillary
-				*(dest+0) =  vucp | (PREAMBLE_B << 16 ) | aux; //special preamble for one of 192 frames								
+				*(dest+0) =  vucp | (PREAMBLE_B << 16 ) | aux; //special preamble for one of 192 frames
 				frame = 0;
 			} else {
 				*(dest+0) = vucp | (PREAMBLE_M << 16 ) | aux;
@@ -192,10 +192,10 @@ void AudioOutputSPDIF::isr(void)
 	} else {
 		do {
 			if ( ++frame > 191 ) {
-				*(dest+0) = 0xcce8cccc;
+				*(dest+0) = vucp | 0x00e8cccc;
 				frame = 0;
 			} else {
-				*(dest+0) = 0xcce2cccc;
+				*(dest+0) = vucp | 0x00e2cccc;
 			}
 			*(dest+1) = 0xccccccccUL;
 
@@ -237,7 +237,7 @@ void AudioOutputSPDIF::isr(void)
 		}
 	} else {
 		do {
-			*dest 	= 0xcce4ccccUL;
+			*dest 	= vucp | 0x00e4ccccUL;
 			*(dest+1) = 0xccccccccUL;
 			dest += 4 ;
 		} while (dest < end);
@@ -247,7 +247,7 @@ void AudioOutputSPDIF::isr(void)
 
 void AudioOutputSPDIF::mute_PCM(const bool mute)
 {
-	vucp = mute?VUCP_INVALID:VUCP_VALID;		
+	vucp = mute?VUCP_INVALID:VUCP_VALID;
 }
 
 void AudioOutputSPDIF::update(void)

--- a/output_spdif.h
+++ b/output_spdif.h
@@ -36,20 +36,20 @@ public:
 	friend class AudioInputSPDIF;
 	static void mute_PCM(const bool mute);
 protected:
-	AudioOutputSPDIF(int dummy): AudioStream(2, inputQueueArray) {}	
+	AudioOutputSPDIF(int dummy): AudioStream(2, inputQueueArray) {}
 	static void config_SPDIF(void);
 	static audio_block_t *block_left_1st;
 	static audio_block_t *block_right_1st;
 	static bool update_responsibility;
 	static DMAChannel dma;
-	static void isr(void);		
+	static void isr(void);
 private:
     static uint32_t vucp;
 	static audio_block_t *block_left_2nd;
 	static audio_block_t *block_right_2nd;
 	static uint16_t block_left_offset;
 	static uint16_t block_right_offset;
-	audio_block_t *inputQueueArray[2];	
+	audio_block_t *inputQueueArray[2];
 };
 
 

--- a/output_spdif.h
+++ b/output_spdif.h
@@ -34,20 +34,22 @@ public:
 	virtual void update(void);
 	void begin(void);
 	friend class AudioInputSPDIF;
+	static void mute_PCM(const bool mute);
 protected:
-	AudioOutputSPDIF(int dummy): AudioStream(2, inputQueueArray) {}
+	AudioOutputSPDIF(int dummy): AudioStream(2, inputQueueArray) {}	
 	static void config_SPDIF(void);
 	static audio_block_t *block_left_1st;
 	static audio_block_t *block_right_1st;
 	static bool update_responsibility;
 	static DMAChannel dma;
-	static void isr(void);
+	static void isr(void);		
 private:
+    static uint32_t vucp;
 	static audio_block_t *block_left_2nd;
 	static audio_block_t *block_right_2nd;
 	static uint16_t block_left_offset;
 	static uint16_t block_right_offset;
-	audio_block_t *inputQueueArray[2];
+	audio_block_t *inputQueueArray[2];	
 };
 
 


### PR DESCRIPTION
Helps to avoid audible clicks when switching from pcm to compressed data.

See https://forum.pjrc.com/threads/29454-AC-3-%28aka-quot-Dolby-Digital-quot-%29-5-1-over-spdif-toslink?p=80356&viewfull=1#post80356