### PR TITLE
Add arm_cortexM4l_math library to linker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ install:
     # install dependent libraries
     # http://platformio.org/#!/lib/show/539/SerialFlash
     - platformio lib install 539
+    
+    - export PLATFORMIO_BUILD_FLAGS=-larm_cortexM4l_math
 
     # remove "extras" directory
     - rm -r extras


### PR DESCRIPTION
@PaulStoffregen you merge this PR. I see that we have problem with @PlatformIO toolchain where is missed `arm_cortexM4l_math` library. We are working on the new version. I'll reply here.