### PR TITLE
Reduce cumulative round-off errors in effect_envelope.

### DIFF
--- a/effect_envelope.h
+++ b/effect_envelope.h
@@ -71,7 +71,7 @@ private:
 	uint16_t milliseconds2count(float milliseconds) {
 		if (milliseconds < 0.0) milliseconds = 0.0;
 		uint32_t c = ((uint32_t)(milliseconds*SAMPLES_PER_MSEC)+7)>>3;
-		if (c > 1103) return 1103; // allow up to 200 ms
+		// if (c > 1103) return 1103; // allow up to 200 ms
 		return c;
 	}
 	audio_block_t *inputQueueArray[1];


### PR DESCRIPTION
Here's a basic implementation of Paul's idea (comment number 12 on https://forum.pjrc.com/threads/27204-Teensy-3-1-Audio-Library-Envelope-limited-to-1000-ms). 

I still need to do some performance comparison, but the code works (tested some 1-2 second attack and release on my synth project, lots of fun). Some improvements can probably be done, any hints are welcome.

This mainly addresses #102, but since longer envelopes states make #107 more likely to be problematic, I also included a very simple fix (just keep the current multiplication factor instead of jumping to the sustain factor).
