### PR TITLE
Access Q-bit from c

### DIFF
--- a/utility/dspinst.h
+++ b/utility/dspinst.h
@@ -333,6 +333,23 @@ static inline int32_t substract_32_saturate(uint32_t a, uint32_t b)
 	return out;
 }
 
+//get Q from PSR
+static inline uint32_t get_q_psr(void) __attribute__((always_inline, unused));
+static inline uint32_t get_q_psr(void)
+{
+  uint32_t out;
+  asm volatile("mrs %0, APSR" : "=r" (out));
+  return (out & 0x8000000)>>27;
+}
 
+//clear Q BIT in PSR
+static inline void clr_q_psr(void) __attribute__((always_inline, unused));
+static inline void clr_q_psr(void)
+{
+  uint32_t t;
+  asm volatile("mrs %0,APSR " : "=r" (t));
+  asm volatile("bfc %0, #27, #1" : "=r" (t));
+  asm volatile("msr APSR_nzcvq,%0" : "=r" (t)); 
+}
 
 #endif


### PR DESCRIPTION
You mentioned in synth_dc.h "// if only C language provided a way to test Q status bit...."
Here it is :) . That return (out & 0x8000000)>>27; translates to only one more instruction : ubfx    r0, r0, #27, #1 , i decided to use the c -variant because it is better readable.

I added a function to clear that bit ( clr_q_psr() ), too. Unfortunately, three instructions are needed (read-modify-write)

Description of (A)PSR :
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CHDBIBGJ.html