### PR TITLE
Optimize CPU Usage

### DIFF
--- a/effect_chorus.cpp
+++ b/effect_chorus.cpp
@@ -100,6 +100,7 @@ void AudioEffectChorus::update(void)
   block = receiveWritable(0);
   if(block) {
     bp = block->data;
+    uint32_t tmp = delay_length/(num_chorus - 1) - 1;
     for(int i = 0;i < AUDIO_BLOCK_SAMPLES;i++) {
       l_circ_idx++;
       if(l_circ_idx >= delay_length) {
@@ -110,7 +111,7 @@ void AudioEffectChorus::update(void)
       c_idx = l_circ_idx;
       for(int k = 0; k < num_chorus; k++) {
         sum += l_delayline[c_idx];
-        if(num_chorus > 1)c_idx -= delay_length/(num_chorus - 1) - 1;
+        if(num_chorus > 1)c_idx -= tmp;
         if(c_idx < 0) {
           c_idx += delay_length;
         }


### PR DESCRIPTION
In my testsketch with 2 x Chorus with n_chrous=4 & #define CHORUS_DELAY_LENGTH (24*AUDIO_BLOCK_SAMPLES),
Cpu-usage decreases from 13.8% to 9.8%