### PR TITLE
faster int32_t substract_32_then_divide (mixed c + assembly)

### DIFF
--- a/synth_dc.h
+++ b/synth_dc.h
@@ -32,20 +32,18 @@
 // compute (a - b) / c
 // handling 32 bit interger overflow at every step
 // without resorting to slow 64 bit math
-#if 0
+#if 1
 // TODO: write this in assembly....
 static inline int32_t substract_32_then_divide(int32_t a, int32_t b, int32_t c) __attribute__((always_inline, unused));
 static inline int32_t substract_32_then_divide(int32_t a, int32_t b, int32_t c)
 {
-	int32_t diff = substract_32_saturate(a, b);
-	// if only C language provided a way to test Q status bit....
-	if (diff != 0x7FFFFFFF && diff != 0x80000000) {
-		return diff / c;
-	} else {
-		diff = substract_32_saturate(a/2, b/2);
-		if (c == 1 || c == -1) c *= 2; // <-- horrible, incorrect hack
-		return (diff / c) * 2;
-	}
+ 	int r;
+ 	r = substract_32_saturate(a,b);
+ 	if ( !get_q_from_psr() ) return (r/c);
+ 	clr_q_psr();
+ 	if ( c==0 ) r=0;
+ 	if (__builtin_abs(c)<=1) return r;
+ 	return (a/c)-(b/c);
 }
 #else
 // compute (a - b) / c  ... handling 32 bit interger overflow without slow 64 bit math

--- a/synth_dc.h
+++ b/synth_dc.h
@@ -33,7 +33,6 @@
 // handling 32 bit interger overflow at every step
 // without resorting to slow 64 bit math
 #if 1
-// TODO: write this in assembly....
 static inline int32_t substract_32_then_divide(int32_t a, int32_t b, int32_t c) __attribute__((always_inline, unused));
 static inline int32_t substract_32_then_divide(int32_t a, int32_t b, int32_t c)
 {

--- a/synth_dc.h
+++ b/synth_dc.h
@@ -33,8 +33,8 @@
 // handling 32 bit interger overflow at every step
 // without resorting to slow 64 bit math
 #if defined(KINETISK)
-static inline int32_t substract_32_then_divide(int32_t a, int32_t b, int32_t c) __attribute__((always_inline, unused));
-static inline int32_t substract_32_then_divide(int32_t a, int32_t b, int32_t c)
+static inline int32_t substract_int32_then_divide_int32(int32_t a, int32_t b, int32_t c) __attribute__((always_inline, unused));
+static inline int32_t substract_int32_then_divide_int32(int32_t a, int32_t b, int32_t c)
 {
  	int r;
  	r = substract_32_saturate(a,b);

--- a/synth_dc.h
+++ b/synth_dc.h
@@ -32,13 +32,13 @@
 // compute (a - b) / c
 // handling 32 bit interger overflow at every step
 // without resorting to slow 64 bit math
-#if 1
+#if defined(KINETISK)
 static inline int32_t substract_32_then_divide(int32_t a, int32_t b, int32_t c) __attribute__((always_inline, unused));
 static inline int32_t substract_32_then_divide(int32_t a, int32_t b, int32_t c)
 {
  	int r;
  	r = substract_32_saturate(a,b);
- 	if ( !get_q_from_psr() ) return (r/c);
+ 	if ( !get_q_psr() ) return (r/c);
  	clr_q_psr();
  	if ( c==0 ) r=0;
  	if (__builtin_abs(c)<=1) return r;

--- a/utility/dspinst.h
+++ b/utility/dspinst.h
@@ -338,7 +338,7 @@ static inline uint32_t get_q_psr(void) __attribute__((always_inline, unused));
 static inline uint32_t get_q_psr(void)
 {
   uint32_t out;
-  asm volatile("mrs %0, APSR" : "=r" (out));
+  asm ("mrs %0, APSR" : "=r" (out));
   return (out & 0x8000000)>>27;
 }
 
@@ -347,9 +347,8 @@ static inline void clr_q_psr(void) __attribute__((always_inline, unused));
 static inline void clr_q_psr(void)
 {
   uint32_t t;
-  asm volatile("mrs %0,APSR " : "=r" (t));
-  asm volatile("bfc %0, #27, #1" : "=r" (t));
-  asm volatile("msr APSR_nzcvq,%0" : "=r" (t)); 
+  asm ("mov %[t],#0\n"
+       "msr APSR_nzcvq,%0\n" : [t] "=&r" (t)::"cc")); 
 }
 
 #endif

--- a/utility/dspinst.h
+++ b/utility/dspinst.h
@@ -348,7 +348,7 @@ static inline void clr_q_psr(void)
 {
   uint32_t t;
   asm ("mov %[t],#0\n"
-       "msr APSR_nzcvq,%0\n" : [t] "=&r" (t)::"cc")); 
+       "msr APSR_nzcvq,%0\n" : [t] "=&r" (t)::"cc"); 
 }
 
 #endif


### PR DESCRIPTION
faster int32_t substract_32_then_divide
absolute worst case: new code 2 cycles faster
best case i've found: new code 30 cycles faster
all my tests showed identical results to the existing function
cycles measured with ARM_DWT_CYCCNT