### PR TITLE
Provide accessor function for envelope state.

### DIFF
--- a/effect_envelope.cpp
+++ b/effect_envelope.cpp
@@ -26,13 +26,6 @@
 
 #include "effect_envelope.h"
 
-#define STATE_IDLE	0
-#define STATE_DELAY	1
-#define STATE_ATTACK	2
-#define STATE_HOLD	3
-#define STATE_DECAY	4
-#define STATE_SUSTAIN	5
-#define STATE_RELEASE	6
 
 void AudioEffectEnvelope::noteOn(void)
 {
@@ -96,10 +89,15 @@ void AudioEffectEnvelope::update(void)
 				inc = ((sustain_mult - 0x10000) / (int32_t)count) >> 3;
 				continue;
 			} else if (state == STATE_DECAY) {
-				state = STATE_SUSTAIN;
-				count = 0xFFFF;
-				mult = sustain_mult;
-				inc = 0;
+			  if (sustain_mult) {
+          state = STATE_SUSTAIN;
+          count = 0xFFFF;
+          mult = sustain_mult;
+          inc = 0;
+				} else {
+				  state = STATE_RELEASE;
+				  continue;
+				}
 			} else if (state == STATE_SUSTAIN) {
 				count = 0xFFFF;
 			} else if (state == STATE_RELEASE) {

--- a/effect_envelope.h
+++ b/effect_envelope.h
@@ -31,11 +31,19 @@
 
 #define SAMPLES_PER_MSEC (AUDIO_SAMPLE_RATE_EXACT/1000.0)
 
+#define STATE_IDLE	0
+#define STATE_DELAY	1
+#define STATE_ATTACK	2
+#define STATE_HOLD	3
+#define STATE_DECAY	4
+#define STATE_SUSTAIN	5
+#define STATE_RELEASE	6
+
 class AudioEffectEnvelope : public AudioStream
 {
 public:
 	AudioEffectEnvelope() : AudioStream(1, inputQueueArray) {
-		state = 0;
+		state = STATE_IDLE;
 		delay(0.0);  // default values...
 		attack(1.5);
 		hold(0.5);
@@ -43,6 +51,7 @@ public:
 		sustain(0.667);
 		release(30.0);
 	}
+	uint8_t getState() { return state; }
 	void noteOn();
 	void noteOff();
 	void delay(float milliseconds) {


### PR DESCRIPTION
It can be useful to know the current state of an AudioEffectEnvelope for visual feedback or to decide when to recycle an audio generator when you have more notes than channels.  This change makes the a public method to provide this information. 