### PR TITLE
Add complex number and phase readouts to AudioAnalyzeFFT1024

### DIFF
--- a/analyze_fft1024.cpp
+++ b/analyze_fft1024.cpp
@@ -107,8 +107,9 @@ void AudioAnalyzeFFT1024::update(void)
 		arm_cfft_radix4_q15(&fft_inst, buffer);
 		// TODO: support averaging multiple copies
 		for (int i=0; i < 512; i++) {
-			uint32_t tmp = *((uint32_t *)buffer + i); // real & imag
-			uint32_t magsq = multiply_16tx16t_add_16bx16b(tmp, tmp);
+			uint32_t cmplx = *((uint32_t *)buffer + i); // the complex result
+			outputCmplx[i] = cmplx;
+			uint32_t magsq = multiply_16tx16t_add_16bx16b(cmplx, cmplx);
 			output[i] = sqrt_uint32_approx(magsq);
 		}
 		outputflag = true;
@@ -128,4 +129,12 @@ void AudioAnalyzeFFT1024::update(void)
 #endif
 }
 
+float AudioAnalyzeFFT1024::readPhase(unsigned int binNumber)
+{
+	if (binNumber > 511) return 0.0;
+	uint32_t cmplxNumber = outputCmplx[binNumber];
+	int16_t realPart = cmplxNumber & 0x0000ffff;
+	int16_t imaginaryPart = cmplxNumber >> 16;
+	return atan2f((float)realPart * (1.0 / 128.0), (float)imaginaryPart * (1.0 / 128.0));
+}
 

--- a/analyze_fft1024.h
+++ b/analyze_fft1024.h
@@ -60,11 +60,36 @@ public:
 		}
 		return false;
 	}
-	float read(unsigned int binNumber) {
+
+	// For details on the internal structure of complex numbers, see the declaration of output[] down below.
+	// Note that only the raw complex numbers and their magnitudes are stored while all phase computations
+	// are done "live" without any form of precalculation.
+	// That's a deliberate design decision since it's unlikely that a user needs all 512 phases.
+	// Moreover, most users don't require the phases anyway.
+	// Instead, the phase retrieval method only computes what the user actually needs and when he needs it.
+	// Although a few users are now responsible for trying to only retrieve each phase once for maximum efficiency,
+	// that's better than wasting a lot of other users' processing time with useless computations.
+	uint32_t readCmplxNumber(unsigned int binNumber) {
+		if (binNumber > 511) return 0;
+		return outputCmplx[binNumber];
+	}
+	int16_t readCmplxRealPart(unsigned int binNumber) {
+		if (binNumber > 511) return 0;
+		return outputCmplx[binNumber] & 0x0000ffff;
+	}
+	int16_t readCmplxImaginaryPart(unsigned int binNumber) {
+		if (binNumber > 511) return 0;
+		return outputCmplx[binNumber] >> 16;
+	}
+	uint16_t readCmplxMagnitude(unsigned int binNumber) {
+		if (binNumber > 511) return 0.0;
+		return output[binNumber];
+	}
+	float readAmplitude(unsigned int binNumber) {
 		if (binNumber > 511) return 0.0;
 		return (float)(output[binNumber]) * (1.0 / 16384.0);
 	}
-	float read(unsigned int binFirst, unsigned int binLast) {
+	float readAmplitudes(unsigned int binFirst, unsigned int binLast) {
 		if (binFirst > binLast) {
 			unsigned int tmp = binLast;
 			binLast = binFirst;
@@ -78,6 +103,8 @@ public:
 		} while (binFirst <= binLast);
 		return (float)sum * (1.0 / 16384.0);
 	}
+	float readPhase(unsigned int binNumber);
+
 	void averageTogether(uint8_t n) {
 		// not implemented yet (may never be, 86 Hz output rate is ok)
 	}
@@ -85,7 +112,15 @@ public:
 		window = w;
 	}
 	virtual void update(void);
-	uint16_t output[512] __attribute__ ((aligned (4)));
+
+	// DEPRECATED members; they exist for backwards compatibility
+	float read(unsigned int binNumber) {
+		return readAmplitude(binNumber);
+	}
+	float read(unsigned int binFirst, unsigned int binLast) {
+		return readAmplitudes(binFirst, binLast);
+	}
+	uint16_t output[512] __attribute__ ((aligned (4))); // stores raw magnitudes; should be private
 private:
 	void init(void);
 	const int16_t *window;
@@ -98,6 +133,11 @@ private:
 	volatile bool outputflag;
 	audio_block_t *inputQueueArray[1];
 	arm_cfft_radix4_instance_q15 fft_inst;
+
+	// Stores a 32-bit complex number for each output bin.
+	// The 16 least significant bits are the real part, the 16 most significant bits are the imaginary part.
+	// Both parts are signed.
+	uint32_t outputCmplx[512] __attribute__ ((aligned (4)));
 };
 
 #endif

--- a/examples/Analysis/FFT/FFT.ino
+++ b/examples/Analysis/FFT/FFT.ino
@@ -60,10 +60,10 @@ void loop() {
 
   if (myFFT.available()) {
     // each time new FFT data is available
-    // print it all to the Arduino Serial Monitor
+    // print the amplitudes to the Arduino Serial Monitor
     Serial.print("FFT: ");
     for (i=0; i<40; i++) {
-      n = myFFT.read(i);
+      n = myFFT.readAmplitude(i);
       if (n >= 0.01) {
         Serial.print(n);
         Serial.print(" ");

--- a/gui/index.html
+++ b/gui/index.html
@@ -2469,8 +2469,9 @@ double s_freq = .0625;</p>
 	<h3>Summary</h3>
 	<div class=tooltipinfo>
 	<p>Compute a 1024 point Fast Fourier Transform (FFT) frequency analysis,
-		with real value (magnitude) output.  The frequency resolution is
-		43 Hz, useful detailed for audio visualization.</p>
+		with complex value output and further computational options like
+		amplitude extraction.  The frequency resolution is 43 Hz, useful
+		detailed for audio visualization.</p>
 	</div>
 	<h3>Audio Connections</h3>
 	<table class=doc align=center cellpadding=3>
@@ -2481,14 +2482,37 @@ double s_freq = .0625;</p>
 	<p class=func><span class=keyword>available</span>();</p>
 	<p class=desc>Returns true each time the FFT analysis produces new output data.
 	</p>
-	<p class=func><span class=keyword>read</span>(binNumber);</p>
-	<p class=desc>Read a single frequency bin, from 0 to 511.  The result is scaled
-		so 1.0 represents a full scale sine wave.
+	<p class=func><span class=keyword>readCmplxNumber</span>(binNumber);</p>
+	<p class=desc>Read a single frequency bin's complex number (uint32_t).  The 16
+		least significant bits represent the real part, the 16 most significant bits
+		represent the imaginary part.  Both parts are signed.
 	</p>
-	<p class=func><span class=keyword>read</span>(firstBin, lastBin);</p>
-	<p class=desc>Read several frequency bins, returning their sum.  The higher
-		audio octaves are represented by many bins, which are typically read
-		as a group for audio visualization.
+	<p class=func><span class=keyword>readCmplxRealPart</span>(binNumber);</p>
+	<p class=desc>Read a single frequency bin complex number's signed real part
+		(int16_t).  That is not the magnitude, but instead "a" from "a + bi".
+	</p>
+	<p class=func><span class=keyword>readCmplxImaginaryPart</span>(binNumber);</p>
+	<p class=desc>Read a single frequency bin complex number's signed imaginary part
+		(int16_t).  That is "b" from "a + bi".
+	</p>
+	<p class=func><span class=keyword>readCmplxMagnitude</span>(binNumber);</p>
+	<p class=desc>Read a single frequency bin complex number's magnitude
+		(uint16_t).  That is the length of the number's vector in the complex plane,
+		which can be computed with "&radic;(a&sup2; + b&sup2;)" considering "a + bi".
+	</p>
+	<p class=func><span class=keyword>readAmplitude</span>(binNumber);</p>
+	<p class=desc>Read a single frequency bin's signal amplitude, from 0 to 511.  The
+		result is scaled so 1.0 represents a full scale sine wave.  This value can be
+		computed by dividing the respective magnitude by 128&sup2; = 16384.
+	</p>
+	<p class=func><span class=keyword>readAmplitudes</span>(firstBin, lastBin);</p>
+	<p class=desc>Read several frequency bins' signal amplitudes, returning their
+		sum.  The higher audio octaves are represented by many bins, which are
+		typically read as a group for audio visualization.
+	</p>
+	<p class=func><span class=keyword>readPhase</span>(binNumber);</p>
+	<p class=desc>Read a single frequency bin's signal phase, from -&pi; to &pi;.  The
+		result is similar to the angle of the number's vector in the complex plane.
 	</p>
 	<p class=func><span class=keyword>averageTogether</span>(number);</p>
 	<p class=desc>This function does nothing.  The 1024 point FFT always
@@ -2506,8 +2530,6 @@ double s_freq = .0625;</p>
 	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; SpectrumAnalyzerBasic
 	</p>
 	<h3>Notes</h3>
-	<p>The raw 16 bit output data bins may be access with myFFT.output[num], where
-		num is 0 to 511.</p>
 	<p>TODO: caveats about spectral leakage vs frequency precision for arbitrary signals</p>
 	<p>Window Types:
 		<ul>


### PR DESCRIPTION
The complex FFT used by the AnalyzeFFT1024 module yields complex numbers both the amplitude and the phase of each frequency bin can be extracted from. However, to this date the module only allows access to the precomputed amplitudes. This PR adds the necessary API functions as well as background code in order to make the following values of each frequency bin available:

* The raw complex numbers
* Their real and imaginary parts
* Their unscaled magnitudes (previously stored in output[])
* The scaled amplitudes
* The scaled phases (-&pi; to &pi;)

Sadly, the old API functions and fields do longer fit into the new naming scheme and thus have been marked as deprecated. Of course, they do still work for the sake of backwards compatibility, even though they are no longer documented. Moreover, this PR adjusts the examples and GUI descriptions so that they reflect the changes as well.

Note that a similar extension of the AnalyzeFFT256 module might be possible, but doesn't make much sense since the results would arrive in such a quick succession that it might be impossible to process them properly, both in the internal code as well as in the user's code.