### PR TITLE
added analogRef to constructor and init, with INTERNAL as default

### DIFF
--- a/input_adc.cpp
+++ b/input_adc.cpp
@@ -36,7 +36,7 @@ bool AudioInputAnalog::update_responsibility = false;
 DMAChannel AudioInputAnalog::dma(false);
 
 
-void AudioInputAnalog::init(uint8_t pin)
+void AudioInputAnalog::init(uint8_t pin, int analogRef)
 {
 	uint32_t i, sum=0;
 
@@ -44,7 +44,9 @@ void AudioInputAnalog::init(uint8_t pin)
 	// conversion.  This completes the self calibration stuff and
 	// leaves the ADC in a state that's mostly ready to use
 	analogReadRes(16);
-	analogReference(INTERNAL); // range 0 to 1.2 volts
+	// DEFAULT: range 0 to 3.3 volts
+	// INTERNAL: range 0 to 1.2 volts
+	analogReference(analogRef);
 	analogReadAveraging(8);
 	// Actually, do many normal reads, to start with a nice DC level
 	for (i=0; i < 1024; i++) {

--- a/input_adc.h
+++ b/input_adc.h
@@ -34,8 +34,8 @@
 class AudioInputAnalog : public AudioStream
 {
 public:
-        AudioInputAnalog() : AudioStream(0, NULL) { init(A2); }
-        AudioInputAnalog(uint8_t pin) : AudioStream(0, NULL) { init(pin); }
+        AudioInputAnalog() : AudioStream(0, NULL) { init(A2, INTERNAL); }
+        AudioInputAnalog(uint8_t pin, int analogRef = INTERNAL) : AudioStream(0, NULL) { init(pin, analogRef); }
         virtual void update(void);
         friend void dma_ch9_isr(void);
 private:
@@ -45,7 +45,7 @@ private:
         static bool update_responsibility;
 	static DMAChannel dma;
 	static void isr(void);
-	static void init(uint8_t pin);
+	static void init(uint8_t pin, int analogRef);
 };
 
 #endif


### PR DESCRIPTION
I added the analogRef as new argument for the AudioAnalogInput constructor. The default
is INTERNAL, so it behaves as the old code when it is not passed in.

This was discussed on:
https://forum.pjrc.com/threads/34865-AudioInputAnalog-reading-from-a-DAC-output