### PR TITLE
fix problem with left+right channels being swapped

### DIFF
--- a/play_sd_wav.cpp
+++ b/play_sd_wav.cpp
@@ -353,6 +353,8 @@ start:
 		data_length -= size;
 		if (leftover_bytes) {
 			block_left->data[block_offset] = header[0];
+//PAH fix problem with left+right channels being swapped
+			leftover_bytes = 0;
 			goto right16;
 		}
 		while (1) {


### PR DESCRIPTION
A bug in play_sd_wav.cpp caused the left and right channels of stereo audio to be swapped in playback if the WAV file has a LIST chunk which is not a multiple of 4 bytes long.