### PR TITLE
Allow play_sd_raw to stream 22050 samples at 44100 for more polyphony

### DIFF
--- a/play_sd_raw.cpp
+++ b/play_sd_raw.cpp
@@ -30,11 +30,17 @@
 
 void AudioPlaySdRaw::begin(void)
 {
+	read_half_SR = false;
 	playing = false;
 	file_offset = 0;
 	file_size = 0;
 }
 
+bool AudioPlaySdRaw::play(const char *filename, bool half_SR)
+{
+	read_half_SR = half_SR;
+	return play(filename);
+}
 
 bool AudioPlaySdRaw::play(const char *filename)
 {
@@ -71,7 +77,6 @@ void AudioPlaySdRaw::update(void)
 {
 	unsigned int i, n;
 	audio_block_t *block;
-
 	// only update if we're playing
 	if (!playing) return;
 
@@ -80,13 +85,27 @@ void AudioPlaySdRaw::update(void)
 	if (block == NULL) return;
 
 	if (rawfile.available()) {
-		// we can read more data from the file...
-		n = rawfile.read(block->data, AUDIO_BLOCK_SAMPLES*2);
-		file_offset += n;
-		for (i=n/2; i < AUDIO_BLOCK_SAMPLES; i++) {
-			block->data[i] = 0;
+ 		// we can read more data from the file...
+		if(read_half_SR) {
+			// read half the samples as normal -- just # of bytes == # of samples
+			n = rawfile.read(temp_block, AUDIO_BLOCK_SAMPLES);
+			file_offset += n;
+			// Double each read sample into the actual trasnmitted block
+			for(i=0;i<AUDIO_BLOCK_SAMPLES;i++) {
+				block->data[i] = temp_block[i/2];
+			}
+			for (i=n; i < AUDIO_BLOCK_SAMPLES; i++) {
+				block->data[i] = 0;
+			}
+			transmit(block);
+		} else {
+			n = rawfile.read(block->data, AUDIO_BLOCK_SAMPLES*2);
+			file_offset += n;
+			for (i=n/2; i < AUDIO_BLOCK_SAMPLES; i++) {
+				block->data[i] = 0;
+			}
+			transmit(block);			
 		}
-		transmit(block);
 	} else {
 		rawfile.close();
 		AudioStopUsingSPI();
@@ -94,6 +113,7 @@ void AudioPlaySdRaw::update(void)
 	}
 	release(block);
 }
+
 
 #define B2M (uint32_t)((double)4294967296000.0 / AUDIO_SAMPLE_RATE_EXACT / 2.0) // 97352592
 

--- a/play_sd_raw.h
+++ b/play_sd_raw.h
@@ -37,12 +37,15 @@ public:
 	AudioPlaySdRaw(void) : AudioStream(0, NULL) { begin(); }
 	void begin(void);
 	bool play(const char *filename);
+	bool play(const char *filename, bool half_SR);
 	void stop(void);
 	bool isPlaying(void) { return playing; }
 	uint32_t positionMillis(void);
 	uint32_t lengthMillis(void);
 	virtual void update(void);
 private:
+	int16_t temp_block[AUDIO_BLOCK_SAMPLES/2];
+	bool read_half_SR;
 	File rawfile;
 	uint32_t file_size;
 	volatile uint32_t file_offset;


### PR DESCRIPTION
I love play_sd_raw but want more than a few notes of polyphony in a sample player. So I added a new optional parameter to AudioPlaySdRaw.play(filename, bool halfSR); if it is true the raw files on the SD card are assumed to be at 22050Hz and played back at 44100 by simply doubling each sample. This lets me easily have around 6-7 notes at once from an SD card.
