### PR TITLE
important fix to correct severe AVC threshold/attack/decay issues

### DIFF
--- a/control_sgtl5000.cpp
+++ b/control_sgtl5000.cpp
@@ -840,9 +840,9 @@ unsigned short AudioControlSGTL5000::autoVolumeControl(uint8_t maxGain, uint8_t 
 	if(maxGain>2) maxGain=2;
 	lbiResponse&=3;
 	hardLimit&=1;
-	uint8_t thresh=(pow(10,threshold/20)*0.636)*pow(2,15);
-	uint8_t att=(1-pow(10,-(attack/(20*44100))))*pow(2,19);
-	uint8_t dec=(1-pow(10,-(decay/(20*44100))))*pow(2,23);
+	uint16_t thresh=(pow(10,threshold/20)*0.636)*pow(2,15);
+	uint16_t att=(1-pow(10,-(attack/(20*44100))))*pow(2,19);
+	uint16_t dec=(1-pow(10,-(decay/(20*44100))))*pow(2,23);
 	write(DAP_AVC_THRESHOLD,thresh);
 	write(DAP_AVC_ATTACK,att);
 	write(DAP_AVC_DECAY,dec);


### PR DESCRIPTION
.. due to truncated variables fed into the SGTL5000 registers.

This fixes issue #209 first discovered in 7/2015, as documented in this [PJRC forum entry](https://forum.pjrc.com/threads/?p=77939#post77939).
Without this fix, the effectiveness of the Automatic Volume Control (AVC) is severely limited, which also compromises it's role as a limiter and safety feature.