### PR TITLE
AudioEffectFade should allow instant fades with fadeIn(0) and fadeOut(0)

### DIFF
--- a/effect_fade.h
+++ b/effect_fade.h
@@ -36,11 +36,19 @@ public:
 	AudioEffectFade(void)
 	  : AudioStream(1, inputQueueArray), position(0xFFFFFFFF) {}
 	void fadeIn(uint32_t milliseconds) {
+		if (milliseconds == 0) {
+			position = 0xFFFFFFFF;
+			return;
+		}
 		uint32_t samples = (uint32_t)(milliseconds * 441u + 5u) / 10u;
 		//Serial.printf("fadeIn, %u samples\n", samples);
 		fadeBegin(0xFFFFFFFFu / samples, 1);
 	}
 	void fadeOut(uint32_t milliseconds) {
+		if (milliseconds == 0) {
+			position = 0;
+			return;
+		}
 		uint32_t samples = (uint32_t)(milliseconds * 441u + 5u) / 10u;
 		//Serial.printf("fadeOut, %u samples\n", samples);
 		fadeBegin(0xFFFFFFFFu / samples, 0);


### PR DESCRIPTION
If you try to fade instantly, it fails as it's trying to divide by zero samples.