### PR TITLE
Add waveshaper effect

### DIFF
--- a/effect_waveshaper.cpp
+++ b/effect_waveshaper.cpp
@@ -1,0 +1,71 @@
+/*
+ * Waveshaper for Teensy 3.X audio
+ *
+ * Copyright (c) 2017 Damien Clarke, http://damienclarke.me
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "effect_waveshaper.h"
+
+void AudioEffectWaveshaper::shape(int16_t* waveshape, int length)
+{
+  // length must be bigger than 1 and equal to a power of two + 1
+  // anything else means we don't continue
+  if(!waveshape || length < 2 || length > 32769 || ((length - 1) & (length - 2))) return;
+
+  this->waveshape = waveshape;
+
+  // set lerpshift to the number of bits to shift while interpolating
+  // to cover the entire waveshape over a uint16_t input range
+  int index = length - 1;
+  lerpshift = 16;
+  while (index >>= 1) --lerpshift;
+}
+
+void AudioEffectWaveshaper::update(void)
+{
+  if(!waveshape) return;
+
+  audio_block_t *block;
+  block = receiveWritable();
+  if (!block) return;
+
+  // performance testing...
+  // unsigned long mcs = micros();
+
+  uint16_t x, xa;
+  int16_t i, ya, yb;
+  for (i = 0; i < AUDIO_BLOCK_SAMPLES; i++) {
+    // bring int16_t data into uint16_t range
+    x = block->data[i] + 32768;
+    // lerp waveshape (from http://coranac.com/tonc/text/fixed.htm)
+    xa = x >> lerpshift;
+    ya = waveshape[xa];
+    yb = waveshape[xa + 1];
+    block->data[i] = ya + ((yb - ya) * (x - (xa << lerpshift)) >> lerpshift);
+  }
+
+  // log performance test without compensating for rollover...
+  // Serial.print("(micros)");
+  // Serial.println(micros() - mcs);
+
+  transmit(block);
+  release(block);
+}

--- a/effect_waveshaper.cpp
+++ b/effect_waveshaper.cpp
@@ -24,13 +24,26 @@
 
 #include "effect_waveshaper.h"
 
-void AudioEffectWaveshaper::shape(int16_t* waveshape, int length)
+AudioEffectWaveshaper::~AudioEffectWaveshaper()
+{
+  if(this->waveshape) {
+    delete [] this->waveshape;
+  }
+}
+
+void AudioEffectWaveshaper::shape(float* waveshape, int length)
 {
   // length must be bigger than 1 and equal to a power of two + 1
   // anything else means we don't continue
   if(!waveshape || length < 2 || length > 32769 || ((length - 1) & (length - 2))) return;
 
-  this->waveshape = waveshape;
+  if(this->waveshape) {
+    delete [] this->waveshape;
+  }
+  this->waveshape = new int16_t[length];
+  for(int i = 0; i < length; i++) {
+    this->waveshape[i] = 32767 * waveshape[i];
+  }
 
   // set lerpshift to the number of bits to shift while interpolating
   // to cover the entire waveshape over a uint16_t input range

--- a/effect_waveshaper.cpp
+++ b/effect_waveshaper.cpp
@@ -47,9 +47,6 @@ void AudioEffectWaveshaper::update(void)
   block = receiveWritable();
   if (!block) return;
 
-  // performance testing...
-  // unsigned long mcs = micros();
-
   uint16_t x, xa;
   int16_t i, ya, yb;
   for (i = 0; i < AUDIO_BLOCK_SAMPLES; i++) {
@@ -61,10 +58,6 @@ void AudioEffectWaveshaper::update(void)
     yb = waveshape[xa + 1];
     block->data[i] = ya + ((yb - ya) * (x - (xa << lerpshift)) >> lerpshift);
   }
-
-  // log performance test without compensating for rollover...
-  // Serial.print("(micros)");
-  // Serial.println(micros() - mcs);
 
   transmit(block);
   release(block);

--- a/effect_waveshaper.h
+++ b/effect_waveshaper.h
@@ -1,0 +1,43 @@
+/*
+ * Waveshaper for Teensy 3.X audio
+ *
+ * Copyright (c) 2017 Damien Clarke, http://damienclarke.me
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef effect_waveshaper_h_
+#define effect_waveshaper_h_
+
+#include "Arduino.h"
+#include "AudioStream.h"
+
+class AudioEffectWaveshaper : public AudioStream
+{
+  public:
+    AudioEffectWaveshaper(void): AudioStream(1, inputQueueArray) {}
+    virtual void update(void);
+    void shape(int16_t* waveshape, int length);
+  private:
+    audio_block_t *inputQueueArray[1];
+    int16_t* waveshape;
+    int16_t lerpshift;
+};
+
+#endif

--- a/effect_waveshaper.h
+++ b/effect_waveshaper.h
@@ -32,8 +32,9 @@ class AudioEffectWaveshaper : public AudioStream
 {
   public:
     AudioEffectWaveshaper(void): AudioStream(1, inputQueueArray) {}
+    ~AudioEffectWaveshaper();
     virtual void update(void);
-    void shape(int16_t* waveshape, int length);
+    void shape(float* waveshape, int length);
   private:
     audio_block_t *inputQueueArray[1];
     int16_t* waveshape;


### PR DESCRIPTION
Hi, I wrote a waveshaper effect because I needed it for an expo converter for LFOs, but the effect itself is good for all kinds of things (overdrives, distortions, fuzzes, phase inversion, approximations of many math functions etc.)

![Waveshaper input vs output](https://github.com/dxinteractive/TeensyAudioWaveshaper/blob/master/docs/example2.gif)

Here the repo where I was devving it which has some rudimentary docs: https://github.com/dxinteractive/TeensyAudioWaveshaper

First let me know if you're keen to merge it, and if there are any implementation or API changes you'd want me to fix up first.

If that's all good, what else should I provide? Examples? Docs for the gui audio tool? Anything else?

Third, given the time I'd like to make a little web tool to let people draw out their waveshape curves, and return the array of values to load into their sketches. Might also be useful for people wanting to use `WAVEFORM_ARBITRARY` with the `synth_waveform`.

### Example usage

```c++
#include <Audio.h>
#include <Wire.h>
#include <SPI.h>
#include <SD.h>
#include <SerialFlash.h>
#include "effect_waveshaper.h"

AudioSynthWaveform waveform;
AudioEffectWaveshaper waveshaper;
AudioOutputI2S output;

AudioConnection patchCord1(waveform, 0, waveshaper, 0);
AudioConnection patchCord2(waveshaper, 0, output, 0);
AudioControlSGTL5000 audioAdaptor;

int16_t WAVESHAPE_EXAMPLE[17] = {
  -19300,
  -19000,
  -18000,
  -16000,
  -13000,
  -10500,
  -7500,
  -4000,
  0,
  4000,
  7500,
  10500,
  13000,
  16000,
  18000,
  19000,
  19300
};

void setup() {
  AudioMemory(40);
  audioAdaptor.enable();
  waveform.begin(1.0, 200.0, WAVEFORM_SINE);
  waveshaper.shape(WAVESHAPE_EXAMPLE, 17);
}

void loop() {
}
```