### PR TITLE
Fix problem with optimized loops like do {} while (!myFFT.available());

### DIFF
--- a/analyze_fft256.h
+++ b/analyze_fft256.h
@@ -110,7 +110,7 @@ private:
 	uint8_t naverage;
 #endif
 	uint8_t count;
-	bool outputflag;
+	volatile bool outputflag;
 	audio_block_t *inputQueueArray[1];
 	arm_cfft_radix4_instance_q15 fft_inst;
 };


### PR DESCRIPTION
https://forum.pjrc.com/threads/46855-AudioAnalyzeFFT256-does-not-work-like-FFT1024-(works-only-once)