### PR TITLE
 add memcpy_tdmtx 

### DIFF
--- a/memcpy_audio.S
+++ b/memcpy_audio.S
@@ -1,5 +1,5 @@
 /* Teensyduino Audio Memcpy
- * Copyright (c) 2016 Frank Bösing
+ * Copyright (c) 2016-2018 Frank Bösing
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -9,10 +9,10 @@
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
  *
- * 1. The above copyright notice and this permission notice shall be 
+ * 1. The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  *
- * 2. If the Software is incorporated into a build system that allows 
+ * 2. If the Software is incorporated into a build system that allows
  * selection among a list of target devices, then similar target
  * devices manufactured by PJRC.COM must be included in the list of
  * target devices and selectable in the same manner.
@@ -53,7 +53,7 @@
 .loopLR:
 	//Load 2*4 words
 	ldmia r1!, {r5,r7,r9,r11}  //1+4
-	ldmia r2!, {r6,r8,r10,r12} //1+4	
+	ldmia r2!, {r6,r8,r10,r12} //1+4
 
 	pkhbt r3,r5,r6,LSL #16	//1
 	pkhtb r4,r6,r5,ASR #16	//1
@@ -68,14 +68,14 @@
 	pkhtb r10,r12,r11,ASR #16	//1
 
 	//Write 8 Words
-	stmia r0!, {r3,r4,r5,r6,r7,r8,r9,r10}	//1+8 -> 5+5+8+9 = 27 Cycles to interleave 32 bytes. 
-	
+	stmia r0!, {r3,r4,r5,r6,r7,r8,r9,r10}	//1+8 -> 5+5+8+9 = 27 Cycles to interleave 32 bytes.
+
 	cmp r14, r0
 	bne .loopLR
 
-	pop	{r4-r11,r14}	
+	pop	{r4-r11,r14}
 #elif AUDIO_BLOCK_SAMPLES == 8
-	push	{r4-r8,r14}	
+	push	{r4-r8,r14}
 
 	ldmia r1!, {r5,r7}
 	ldmia r2!, {r6,r8}
@@ -87,11 +87,11 @@
 	pkhtb r6,r8,r7,ASR #16
 
 	stmia r0!, {r3,r4,r5,r6}
-	pop	{r4-r8,r14}	
+	pop	{r4-r8,r14}
 #endif
 	BX lr
-	
-	
+
+
 /* void memcpy_tointerleaveL(short *dst, short *srcL); */
  .global	memcpy_tointerleaveL
 .thumb_func
@@ -99,9 +99,9 @@
 
 	@ r0: dst
 	@ r1: srcL
-	
+
 	mov r2, #0
-	
+
 #if AUDIO_BLOCK_SAMPLES > 8
 	push	{r4-r11}
 	add r12,r0,#(AUDIO_BLOCK_SAMPLES*2)
@@ -132,7 +132,7 @@
 	pop	{r4-r11}
 #elif AUDIO_BLOCK_SAMPLES == 8
 	push	{r4-r7}
-	
+
 	ldmia r1!, {r5,r7}
 
 	pkhbt r3,r5,r2
@@ -142,12 +142,12 @@
 	pkhtb r6,r2,r7,ASR #16
 
 	stmia r0!, {r3,r4,r5,r6}
-	
+
 	pop	{r4-r7}
-#endif	
+#endif
 	BX lr
 
-	
+
 /* void memcpy_tointerleaveL(short *dst, short *srcR); */
  .global	memcpy_tointerleaveR
 .thumb_func
@@ -185,9 +185,9 @@
 	bne .loopR
 
 	pop	{r4-r11}
-#elif AUDIO_BLOCK_SAMPLES == 8	
+#elif AUDIO_BLOCK_SAMPLES == 8
 	push	{r4-r7}
-	
+
 	ldmia r1!, {r5,r7}
 
 	pkhbt r3,r2,r5,LSL #16
@@ -195,12 +195,12 @@
 
 	pkhbt r5,r2,r7,LSL #16
 	pkhtb r6,r7,r2
-	
+
 	stmia r0!, {r3,r4,r5,r6}
 
 	pop	{r4-r7}
 
-#endif	
+#endif
 	BX lr
 
 
@@ -238,6 +238,51 @@
 
 	pop	{r4-r11}
 	BX lr
-.END
 
+
+	
+/* void memcpy_tdmtx(uint32_t *dest, const uint32_t *src1, const uint32_t *src2) */
+ .global	memcpy_tdmtx
+.thumb_func
+	memcpy_tdmtx:
+
+	@ r0: dst
+	@ r1: src1
+	@ r2: src2
+
+  push {r4-r11, r14}
+	add r14,r0,#((AUDIO_BLOCK_SAMPLES/2)*64)
+
+  .align 2
+.looptdmtx:
+	ldmia r1!,{r3, r6, r8, r10}
+	ldmia r2!,{r4, r7, r9, r11}
+
+	pkhbt r5,r4,r3,LSL #16
+	str   r5, [r0], #32
+	pkhtb r5,r3,r4,ASR #16
+	str   r5, [r0], #32
+
+	pkhbt r5,r7,r6,LSL #16
+	str   r5, [r0], #32
+	pkhtb r5,r6,r7,ASR #16
+	str   r5, [r0], #32
+
+	pkhbt r5,r9,r8,LSL #16
+	str   r5, [r0], #32
+	pkhtb r5,r8,r9,ASR #16
+	str   r5, [r0], #32
+
+	pkhbt r5,r11,r10,LSL #16
+	str   r5, [r0], #32
+	pkhtb r5,r10,r11,ASR #16
+	str   r5, [r0], #32
+
+	cmp r14, r0
+	bne .looptdmtx
+	pop  {r4-r11, r14}
+
+	BX lr
+
+.END
 #endif

--- a/memcpy_audio.h
+++ b/memcpy_audio.h
@@ -1,5 +1,5 @@
 /* Teensyduino Audio Memcpy
- * Copyright (c) 2016 Frank Bösing
+ * Copyright (c) 2016-2018 Frank Bösing
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -38,6 +38,7 @@ void memcpy_tointerleaveL(int16_t *dst, const int16_t *srcL);
 void memcpy_tointerleaveR(int16_t *dst, const int16_t *srcR);
 void memcpy_tointerleaveQuad(int16_t *dst, const int16_t *src1, const int16_t *src2,
 	const int16_t *src3, const int16_t *src4);
+void memcpy_tdmtx(uint32_t *dest, const uint32_t *src1, const uint32_t *src2);	
 #ifdef __cplusplus
 }
 #endif

--- a/output_tdm.cpp
+++ b/output_tdm.cpp
@@ -70,7 +70,7 @@ void AudioOutputTDM::begin(void)
 	dma.attachInterrupt(isr);
 }
 
-// TODO: needs optimization...
+#if 0
 static void memcpy_tdm_tx(uint32_t *dest, const uint32_t *src1, const uint32_t *src2)
 {
 	uint32_t i, in1, in2, out1, out2;
@@ -85,6 +85,7 @@ static void memcpy_tdm_tx(uint32_t *dest, const uint32_t *src1, const uint32_t *
 		dest += 16;
 	}
 }
+#endif
 
 void AudioOutputTDM::isr(void)
 {
@@ -107,7 +108,8 @@ void AudioOutputTDM::isr(void)
 	for (i=0; i < 16; i += 2) {
 		src1 = block_input[i] ? (uint32_t *)(block_input[i]->data) : zeros;
 		src2 = block_input[i+1] ? (uint32_t *)(block_input[i+1]->data) : zeros;
-		memcpy_tdm_tx(dest, src1, src2);
+		//memcpy_tdm_tx(dest, src1, src2);
+		memcpy_tdmtx(dest, src1, src2);
 		dest++;
 	}
 	for (i=0; i < 16; i++) {
@@ -201,7 +203,7 @@ void AudioOutputTDM::config_tdm(void)
 	I2S0_TCR2 = I2S_TCR2_SYNC(0) | I2S_TCR2_BCP | I2S_TCR2_MSEL(1)
 		| I2S_TCR2_BCD | I2S_TCR2_DIV(0);
 	I2S0_TCR3 = I2S_TCR3_TCE;
-	I2S0_TCR4 = I2S_TCR4_FRSZ(7) | I2S_TCR4_SYWD(0) | I2S_TCR4_MF
+	I2S0_TCR4 = I2S_TCR4_FRSZ(7) | I2S_TCR4_SYWD(63) | I2S_TCR4_MF
 		| I2S_TCR4_FSE | I2S_TCR4_FSD;
 	I2S0_TCR5 = I2S_TCR5_WNW(31) | I2S_TCR5_W0W(31) | I2S_TCR5_FBT(31);
 
@@ -211,7 +213,7 @@ void AudioOutputTDM::config_tdm(void)
 	I2S0_RCR2 = I2S_RCR2_SYNC(1) | I2S_TCR2_BCP | I2S_RCR2_MSEL(1)
 		| I2S_RCR2_BCD | I2S_RCR2_DIV(0);
 	I2S0_RCR3 = I2S_RCR3_RCE;
-	I2S0_RCR4 = I2S_RCR4_FRSZ(7) | I2S_RCR4_SYWD(0) | I2S_RCR4_MF
+	I2S0_RCR4 = I2S_RCR4_FRSZ(7) | I2S_RCR4_SYWD(15) | I2S_RCR4_MF
 		| I2S_RCR4_FSE | I2S_RCR4_FSD;
 	I2S0_RCR5 = I2S_RCR5_WNW(31) | I2S_RCR5_W0W(31) | I2S_RCR5_FBT(31);
 


### PR DESCRIPTION
T3.5, 98 MHz, -O2, Blocksize 128, 1000x calls to memcopy,
in C (original) 10504 microsconds,
asm 6581 microseconds.

Testsketch attached.

[sketch_oct02a.zip](https://github.com/PaulStoffregen/Audio/files/2437640/sketch_oct02a.zip)
