### PR TITLE
Add member restart() to AudioSynthWaveform

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -2150,6 +2150,14 @@ The actual packets are taken
 		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
 		should be used to guarantee all new settings take effect together.
 	</p>
+	<p class=func><span class=keyword>restart</span>();</p>
+	<p class=desc>
+		Cause the generated waveform to restart its cycle. The generation
+		starts with the angle 0 degrees (default) or with the last value
+		configured by phase(angle);. When multiple objects are configured,
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
+		should be used to guarantee all new settings take effect together.
+	</p>
 	<p class=func><span class=keyword>pulseWidth</span>(amount);</p>
 	<p class=desc>Change the width (duty cycle) of the pulse.</p>
 	<p class=func><span class=keyword>arbitraryWaveform</span>(array, maxFreq);</p>

--- a/synth_waveform.h
+++ b/synth_waveform.h
@@ -75,6 +75,9 @@ public:
 		}
 		phase_offset = angle * (4294967296.0 / 360.0);
 	}
+	void restart() {
+		phase_accumulator = 0;
+	}
 	void amplitude(float n) {	// 0 to 1.0
 		if (n < 0) {
 			n = 0;


### PR DESCRIPTION
The phase(angle) method sets the phase relative to the current angle. A LFO application need to set the phase to an absolute angle. The new method restart() sets the phase_accumulator to zero. The waveform is restarted with an absolute angle defined by phase(angle).