### PR TITLE
Bugfix for missing initialization of data pointers in AudioPlaySdWav

### DIFF
--- a/play_sd_wav.h
+++ b/play_sd_wav.h
@@ -34,7 +34,7 @@
 class AudioPlaySdWav : public AudioStream
 {
 public:
-	AudioPlaySdWav(void) : AudioStream(0, NULL) { begin(); }
+	AudioPlaySdWav(void) : AudioStream(0, NULL), block_left(NULL), block_right(NULL) { begin(); }
 	void begin(void);
 	bool play(const char *filename);
 	void stop(void);


### PR DESCRIPTION
If `AudioPlaySdWav::block_left` / `block_right` are not properly initialized to `NULL`, `AudioPlaySdWav::begin()` may crash, because their usage in `AudioStream::release()` may lead to undefined behavior.