### PR TITLE
Fix i2s-input for Imxrt

### DIFF
--- a/input_i2s.cpp
+++ b/input_i2s.cpp
@@ -68,6 +68,8 @@ void AudioInputI2S::begin(void)
 #elif defined(__IMXRT1052__) || defined(__IMXRT1062__)
 
 	CORE_PIN7_CONFIG  = 3;  //1:RX_DATA0
+	IOMUXC_SAI1_RX_DATA0_SELECT_INPUT = 2;
+	
 	dma.TCD->SADDR = (void *)((uint32_t)&I2S1_RDR0+2);
 	dma.TCD->SOFF = 0;
 	dma.TCD->ATTR = DMA_TCD_ATTR_SSIZE(1) | DMA_TCD_ATTR_DSIZE(1);
@@ -81,16 +83,9 @@ void AudioInputI2S::begin(void)
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
 
-//	I2S1_RCSR = 0;
-//	I2S1_TCSR = 0;
-//	I2S1_RCSR = (1<<25); //Reset
-//	I2S1_TCSR = (1<<25); //Reset
 	I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE;
 	I2S1_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE;
-/*
-	I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
-	I2S1_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
-*/
+
 #endif
 
 	update_responsibility = update_setup();
@@ -206,16 +201,15 @@ void AudioInputI2S::update(void)
 
 void AudioInputI2Sslave::begin(void)
 {
-#if 0
 	dma.begin(true); // Allocate the DMA channel first
 
 	//block_left_1st = NULL;
 	//block_right_1st = NULL;
 
 	AudioOutputI2Sslave::config_i2s();
-
-	CORE_PIN13_CONFIG = PORT_PCR_MUX(4); // pin 13, PTC5, I2S0_RXD0
 #if defined(KINETISK)
+	CORE_PIN13_CONFIG = PORT_PCR_MUX(4); // pin 13, PTC5, I2S0_RXD0
+
 	dma.TCD->SADDR = (void *)((uint32_t)&I2S0_RDR0 + 2);
 	dma.TCD->SOFF = 0;
 	dma.TCD->ATTR = DMA_TCD_ATTR_SSIZE(1) | DMA_TCD_ATTR_DSIZE(1);
@@ -227,7 +221,7 @@ void AudioInputI2Sslave::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(i2s_rx_buffer);
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_rx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
-#endif
+
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_RX);
 	update_responsibility = update_setup();
 	dma.enable();
@@ -235,6 +229,7 @@ void AudioInputI2Sslave::begin(void)
 	I2S0_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
 	dma.attachInterrupt(isr);
-#endif
+#endif	
+
 }
 


### PR DESCRIPTION
adds missing IOMUXC_SAI1_RX_DATA0_SELECT_INPUT = 2;