### PR TITLE
'fixed' an import issue when some block inputs where unconnected.

### DIFF
--- a/gui/red/nodes.js
+++ b/gui/red/nodes.js
@@ -663,6 +663,10 @@ RED.nodes = (function() {
 				for (var w1=0;w1<n.wires.length;w1++) {
 					var wires = (n.wires[w1] instanceof Array)?n.wires[w1]:[n.wires[w1]];
 					for (var w2=0;w2<wires.length;w2++) {
+                        if (!wires[w2]) {
+                            console.log('RED:nodes: murks in wire #', w1, ' of:', n.name, n);
+                            continue;
+                        }
 						var parts = wires[w2].split(":");
 						if (parts.length == 2 && parts[0] in node_map) {
 							var dst = node_map[parts[0]];


### PR DESCRIPTION
I had trouble (re)importing below code in the GUI. Seems to be related to unconnected inputs.

Added a little check to avoid throwing an exception, so all the "correct" patchCords get imported anyway.

Cheers.

`
// GUItool: begin automatically generated code
AudioInputI2S            i2sIn;          //xy=115.01885986328125,299.00000262260437
AudioFilterStateVariable filter1;        //xy=132.76885223388672,235.2499771118164
AudioFilterStateVariable filter2;        //xy=133.76886367797852,360.25
AudioMixer4              mixerIn1;       //xy=265.02356338500977,236.2735824584961
AudioMixer4              mixerIn2;       //xy=266.27357482910156,362.5235843658447
AudioOutputI2S           i2sOut;         //xy=945.0188598632812,145.00000262260437
AudioConnection          patchCord1(i2sIn, 0, filter1, 0);
AudioConnection          patchCord2(i2sIn, 1, filter2, 0);
AudioConnection          patchCord3(filter1, 2, mixerIn1, 0);
AudioConnection          patchCord4(filter1, 2, mixerIn2, 1);
AudioConnection          patchCord5(filter2, 2, mixerIn2, 0);
AudioConnection          patchCord6(filter2, 2, mixerIn1, 1);
AudioConnection          patchCord31(mixerIn1, 0, i2sOut, 0);
AudioConnection          patchCord35(mixerIn2, 0, i2sOut, 0);
// GUItool: end automatically generated code
`