### PR TITLE
PT8211: Fix Teensy 3.x

### DIFF
--- a/output_pt8211.cpp
+++ b/output_pt8211.cpp
@@ -71,8 +71,11 @@ void AudioOutputPT8211::begin(void)
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_TX);
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
+	dma.enable();
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE | I2S_TCSR_FR;
-
+	return;
 #elif defined(__IMXRT1052__) || defined(__IMXRT1062__)
 
 #if defined(__IMXRT1052__)
@@ -96,10 +99,12 @@ void AudioOutputPT8211::begin(void)
 
 	I2S1_RCSR |= I2S_RCSR_RE;
 	I2S1_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
-#endif
+
 	update_responsibility = update_setup();
 	dma.attachInterrupt(isr);
 	dma.enable();
+	return;
+#endif	
 }
 
 void AudioOutputPT8211::isr(void)


### PR DESCRIPTION
dma.enable() needs to be called before setting I2S0_TCSR