### PR TITLE
Remove AUDIO_SAMPLE_RATE_EXACT hack for Teensy-LC

### DIFF
--- a/output_dac.cpp
+++ b/output_dac.cpp
@@ -183,7 +183,7 @@ void AudioOutputAnalog::begin(void)
 	// commandeer FTM1 for timing (PWM on pin 3 & 4 will become 22 kHz)
 	FTM1_SC = 0;
 	FTM1_CNT = 0;
-	FTM1_MOD = (uint32_t)((F_PLL/2) / 44117.64706/*AUDIO_SAMPLE_RATE_EXACT*/ + 0.5);
+	FTM1_MOD = (uint32_t)((F_PLL/2) / AUDIO_SAMPLE_RATE_EXACT + 0.5);
 	FTM1_SC = FTM_SC_CLKS(1) | FTM_SC_DMA;
 
 	dma1.sourceBuffer(dac_buffer1, sizeof(dac_buffer1));


### PR DESCRIPTION
The idea here would be to make this change globally in `AudioStream.h` rather than locally with a hacky override in `output_dac.cpp`.  Please consider this change in conjunction with PaulStoffregen/cores#456, which makes the corresponding change in `AudioStream.h`.

Originally hacked in 0e187cb34c8ee7853b5b9abbac7f47708a0ca0b8 (#313).