### PR TITLE
Granular documentation fix

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -3236,7 +3236,7 @@ double s_freq = .0625;</p>
 		at altered speed.  The grainLength is specified in milliseconds, up to
 		one third of the memory from begin();
 		</p>
-	<p class=func><span class=keyword>end</span>();</p>
+	<p class=func><span class=keyword>stop</span>();</p>
 	<p class=desc>Stop granual processing.  The input signal is passed to the
 		output without any changes.
 		</p>


### PR DESCRIPTION
The documentation for the granular effect says there is an 'end' function but it is actually 'stop'. Not a big deal but it tripped me up.