### PR TITLE
Switch headphone source between input and DAC

### DIFF
--- a/control_sgtl5000.h
+++ b/control_sgtl5000.h
@@ -29,6 +29,10 @@
 
 #include "AudioControl.h"
 
+// SGTL5000-specific defines for headphones
+#define AUDIO_HEADPHONE_DAC 0
+#define AUDIO_HEADPHONE_LINEIN 1
+
 class AudioControlSGTL5000 : public AudioControl
 {
 public:
@@ -50,6 +54,15 @@ public:
 			return write(0x002A, 0x0173) // mic preamp gain = +40dB
 			 && write(0x0020, 0x088)     // input gain +12dB (is this enough?)
 			 && write(0x0024, ana_ctrl & ~(1<<2)); // enable mic
+		} else {
+			return false;
+		}
+	}
+	bool headphoneSelect(int n) {
+		if (n == AUDIO_HEADPHONE_DAC) {
+			return write(0x0024, ana_ctrl | (1<<6)); // route DAC to headphones out
+		} else if (n == AUDIO_HEADPHONE_LINEIN) {
+			return write(0x0024, ana_ctrl & ~(1<<6)); // route linein to headphones out
 		} else {
 			return false;
 		}


### PR DESCRIPTION
SGTL5000 supports switching between linein and DAC as the source of the headphone output, but it was not yet exposed by the `AudioControlSGTL5000` class. 