### PR TITLE
corrected include path

### DIFF
--- a/analyze_fft1024.cpp
+++ b/analyze_fft1024.cpp
@@ -26,7 +26,7 @@
 
 #include <Arduino.h>
 #include "analyze_fft1024.h"
-#include "sqrt_integer.h"
+#include "utility/sqrt_integer.h"
 #include "utility/dspinst.h"
 
 

--- a/analyze_fft256.cpp
+++ b/analyze_fft256.cpp
@@ -26,7 +26,7 @@
 
 #include <Arduino.h>
 #include "analyze_fft256.h"
-#include "sqrt_integer.h"
+#include "utility/sqrt_integer.h"
 #include "utility/dspinst.h"
 
 

--- a/synth_wavetable.cpp
+++ b/synth_wavetable.cpp
@@ -26,7 +26,7 @@
 
 #include <Arduino.h>
 #include "synth_wavetable.h"
-#include <dspinst.h>
+#include <utility/dspinst.h>
 #include <SerialFlash.h>
 
 //#define TIME_TEST_ON


### PR DESCRIPTION
I wasn't able to build the audio library using cmake because these include paths were incorrect. Once corrected, audio code compiles in both Arduino and using CMake... 

I'd appreciate if you could consider merging this change in to master? Thank you :) 