### PR TITLE
Fix discontinuity in frequency stepping in tonesweep

### DIFF
--- a/synth_tonesweep.cpp
+++ b/synth_tonesweep.cpp
@@ -97,13 +97,14 @@ void AudioSynthToneSweep::update(void)
   if(block) {
     bp = block->data;
     uint32_t tmp  = tone_freq >> 32; 
-    uint64_t tone_tmp = (0x400000000000LL * (int)(tmp&0x7fffffff)) / (int) AUDIO_SAMPLE_RATE_EXACT;
+    uint64_t tone_tmp = (tone_freq << 14) / (int) AUDIO_SAMPLE_RATE_EXACT;
+    uint64_t incr     = (tone_incr << 14) / (int) AUDIO_SAMPLE_RATE_EXACT;
     // Generate the sweep
     for(i = 0;i < AUDIO_BLOCK_SAMPLES;i++) {
       *bp++ = (short)(( (short)(arm_sin_q31((uint32_t)((tone_phase >> 15)&0x7fffffff))>>16) *tone_amp) >> 15);
 
       tone_phase +=  tone_tmp;
-      if(tone_phase & 0x800000000000LL)tone_phase &= 0x7fffffffffffLL;
+      tone_tmp   +=  incr ;
 
       if(tone_sign > 0) {
         if(tmp > tone_hi) {


### PR DESCRIPTION
The frequency adjustment per sample wasn't being applied to the phase on every sample, only per block, so
the sweep frequency was stepped and thus spectrally compromised.

See: https://forum.pjrc.com/threads/61855-A-subharmonic-synthesiser-and-polymetric-sequencer-with-Teensy-4-and-audio-library#8

This change should be low-impact to existing code, simply improving tone sweep quality.

Also removed unnecessary/incorrect masking of phase top bits which are dont-care.