### PR TITLE
*CREATED IN ERROR PLEASE IGNORE* Phase modulation overdrive

### DIFF
--- a/synth_tonesweep.cpp
+++ b/synth_tonesweep.cpp
@@ -97,13 +97,14 @@ void AudioSynthToneSweep::update(void)
   if(block) {
     bp = block->data;
     uint32_t tmp  = tone_freq >> 32; 
-    uint64_t tone_tmp = (0x400000000000LL * (int)(tmp&0x7fffffff)) / (int) AUDIO_SAMPLE_RATE_EXACT;
+    uint64_t tone_tmp = (tone_freq << 14) / (int) AUDIO_SAMPLE_RATE_EXACT;
+    uint64_t incr     = (tone_incr << 14) / (int) AUDIO_SAMPLE_RATE_EXACT;
     // Generate the sweep
     for(i = 0;i < AUDIO_BLOCK_SAMPLES;i++) {
       *bp++ = (short)(( (short)(arm_sin_q31((uint32_t)((tone_phase >> 15)&0x7fffffff))>>16) *tone_amp) >> 15);
 
       tone_phase +=  tone_tmp;
-      if(tone_phase & 0x800000000000LL)tone_phase &= 0x7fffffffffffLL;
+      tone_tmp   +=  incr ;
 
       if(tone_sign > 0) {
         if(tmp > tone_hi) {

--- a/synth_tonesweep.cpp
+++ b/synth_tonesweep.cpp
@@ -97,14 +97,13 @@ void AudioSynthToneSweep::update(void)
   if(block) {
     bp = block->data;
     uint32_t tmp  = tone_freq >> 32; 
-    uint64_t tone_tmp = (tone_freq << 14) / (int) AUDIO_SAMPLE_RATE_EXACT;
-    uint64_t incr     = (tone_incr << 14) / (int) AUDIO_SAMPLE_RATE_EXACT;
+    uint64_t tone_tmp = (0x400000000000LL * (int)(tmp&0x7fffffff)) / (int) AUDIO_SAMPLE_RATE_EXACT;
     // Generate the sweep
     for(i = 0;i < AUDIO_BLOCK_SAMPLES;i++) {
       *bp++ = (short)(( (short)(arm_sin_q31((uint32_t)((tone_phase >> 15)&0x7fffffff))>>16) *tone_amp) >> 15);
 
       tone_phase +=  tone_tmp;
-      tone_tmp   +=  incr ;
+      if(tone_phase & 0x800000000000LL)tone_phase &= 0x7fffffffffffLL;
 
       if(tone_sign > 0) {
         if(tmp > tone_hi) {

--- a/synth_waveform.cpp
+++ b/synth_waveform.cpp
@@ -244,7 +244,7 @@ void AudioSynthWaveformModulated::update(void)
 		for (i=0; i < AUDIO_BLOCK_SAMPLES; i++) {
 			// more than +/- 180 deg shift by 32 bit overflow of "n"
 			uint32_t n = (uint16_t)(*bp++) * modulation_factor;
-			phasedata[i] = ph + n;
+			phasedata[i] = ph + (n<<phase_overdrive);
 			ph += inc;
 		}
 		release(moddata);

--- a/synth_waveform.h
+++ b/synth_waveform.h
@@ -133,7 +133,7 @@ public:
 	AudioSynthWaveformModulated(void) : AudioStream(2, inputQueueArray),
 		phase_accumulator(0), phase_increment(0), modulation_factor(32768),
 		magnitude(0), arbdata(NULL), sample(0), tone_offset(0),
-		tone_type(WAVEFORM_SINE), modulation_type(0) {
+		tone_type(WAVEFORM_SINE), modulation_type(0), phase_overdrive(0) {
 	}
 
 	void frequency(float freq) {
@@ -190,6 +190,10 @@ public:
 		modulation_factor = degrees * (65536.0 / 180.0);
 		modulation_type = 1;
 	}
+        void phaseOverdrive (int lshift)
+        {
+	  phase_overdrive = lshift ;
+	}
 	virtual void update(void);
 
 private:
@@ -204,6 +208,7 @@ private:
 	int16_t  tone_offset;
 	uint8_t  tone_type;
 	uint8_t  modulation_type;
+        uint8_t  phase_overdrive;
 };
 
 


### PR DESCRIPTION
Fix phase modulation in AudioSynthWaveformModulated to prevent discontinuities if modulation_factor
happens not to be a multiple of 180 degrees.