### PR TITLE
Added option to specify ADC when initialising AudioInputAnalog

### DIFF
--- a/input_adc.h
+++ b/input_adc.h
@@ -36,6 +36,7 @@ class AudioInputAnalog : public AudioStream
 public:
         AudioInputAnalog() : AudioStream(0, NULL) { init(A2); }
         AudioInputAnalog(uint8_t pin) : AudioStream(0, NULL) { init(pin); }
+        AudioInputAnalog(uint8_t pin, int8_t adc_num) : AudioStream(0, NULL) { init(pin,adc_num); }
         virtual void update(void);
 private:
         static audio_block_t *block_left;
@@ -47,6 +48,7 @@ private:
         static DMAChannel dma;
         static void isr(void);
         static void init(uint8_t pin);
+        static void init(uint8_t pin, uint8_t adc_num);
 
 };
 


### PR DESCRIPTION
Currently, AudioInputAnalog only uses ADC0. This adds an additional init function to specify which ADC to use. 

This is useful as many of the outer pins on the 3,2 are only accessible through ADC0 as such could not be used in conjunction with AudioInputAnalog.

Code to initialise ADC1 has been adapted from input_adcs.cpp currently uses both ADC0 and ADC1 https://github.com/PaulStoffregen/Audio/blob/32174852ce5e4f6f326e6914891816b42615e41d/input_adcs.cpp#L50

Hope this helps!