### PR TITLE
AsyncAudioInputSPDIF3 minor bug fix/clipping prevention

### DIFF
--- a/async_input_spdif3.h
+++ b/async_input_spdif3.h
@@ -43,7 +43,7 @@ public:
 	///@param attenuation target attenuation [dB] of the anti-aliasing filter. Only used if AUDIO_SAMPLE_RATE_EXACT < input sample rate (input fs). The attenuation can't be reached if the needed filter length exceeds 2*MAX_FILTER_SAMPLES+1
 	///@param minHalfFilterLength If AUDIO_SAMPLE_RATE_EXACT >= input fs), the filter length of the resampling filter is 2*minHalfFilterLength+1. If AUDIO_SAMPLE_RATE_EXACT < input fs the filter is maybe longer to reach the desired attenuation
 	///@param maxHalfFilterLength Can be used to restrict the maximum filter length at the cost of a lower attenuation
-	AsyncAudioInputSPDIF3(bool dither=true, bool noiseshaping=true,float attenuation=100, int32_t minHalfFilterLength=20, int32_t maxHalfFilterLength=80);
+	AsyncAudioInputSPDIF3(bool dither=false, bool noiseshaping=false,float attenuation=100, int32_t minHalfFilterLength=20, int32_t maxHalfFilterLength=80);
 	~AsyncAudioInputSPDIF3();
 	void begin();
 	virtual void update(void);

--- a/examples/HardwareTesting/PassThroughAsyncSpdif/PassThroughAsyncSpdif.ino
+++ b/examples/HardwareTesting/PassThroughAsyncSpdif/PassThroughAsyncSpdif.ino
@@ -1,7 +1,7 @@
 
 #include <Audio.h>
 
-AsyncAudioInputSPDIF3     spdifIn(false, false, 100, 20, 80);	//dither = true, noiseshaping = true, anti-aliasing attenuation=100dB, minimum half resampling filter length=20, maximum half resampling filter length=80
+AsyncAudioInputSPDIF3     spdifIn(false, false, 100, 20, 80);	//dither = false, noiseshaping = false, anti-aliasing attenuation=100dB, minimum half resampling filter length=20, maximum half resampling filter length=80
 AudioOutputSPDIF3   spdifOut;
 
 AudioConnection          patchCord1(spdifIn, 0, spdifOut, 0);


### PR DESCRIPTION
- Quantizer: minor bug fix: missing minus added when limiting the signal to -(2^15-1).
- Quantizer: Upper bound for noise shaping and dithering values computed to prevent clipping.
- AsyncAudioInputSPDIF3 disabled dither and noise shaping at the default constructor arguments.
- Example: comment corrected