### PR TITLE
sg5k: calcBiquad: add missing break; for hishelf

### DIFF
--- a/control_sgtl5000.cpp
+++ b/control_sgtl5000.cpp
@@ -1000,6 +1000,7 @@ void calcBiquad(uint8_t filtertype, float fC, float dB_Gain, float Q, uint32_t q
     a0 = (A+1.0F) - ((A-1.0F)*cosw) + (beta*sinw);
     a1 = -2.0F * ((A-1.0F) - ((A+1.0F)*cosw));
     a2 = -((A+1.0F) - ((A-1.0F)*cosw) - (beta*sinw));
+  break;
   default:
     b0 = 0.5;
     b1 = 0.0;


### PR DESCRIPTION
There was a missing `break;` at the end of the FILTER_HISHELF
case in the calculations, meaning a hishelf coeff calc always
returned the default fallthrough case, which is a benign passthrough
filter.

Fix by adding the `break;`.

Fixes: #343

Signed-off-by: Graham Whaley <graham.whaley@gmail.com>