### PR TITLE
Fixes for Teensy LC

### DIFF
--- a/analyze_fft256.cpp
+++ b/analyze_fft256.cpp
@@ -60,7 +60,7 @@ void AudioAnalyzeFFT256::update(void)
 
 	block = receiveReadOnly();
 	if (!block) return;
-#if AUDIO_BLOCK_SAMPLES == 128
+#if AUDIO_BLOCK_SAMPLES == 128 && defined (__ARM_ARCH_7EM__)
 	if (!prevblock) {
 		prevblock = block;
 		return;

--- a/input_pdm.cpp
+++ b/input_pdm.cpp
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
- #if !defined(__IMXRT1052__) && !defined(__IMXRT1062__)
+#if defined(KINETISK)
  
 #include <Arduino.h>
 #include "input_pdm.h"

--- a/utility/dspinst.h
+++ b/utility/dspinst.h
@@ -193,7 +193,7 @@ static inline uint32_t pack_16x16(int32_t a, int32_t b)
 	return out;
 }
 */
-
+#if defined (__ARM_ARCH_7EM__)
 // computes (((a[31:16] + b[31:16]) << 16) | (a[15:0 + b[15:0]))  (saturates)
 static inline uint32_t signed_add_16_and_16(uint32_t a, uint32_t b) __attribute__((always_inline, unused));
 static inline uint32_t signed_add_16_and_16(uint32_t a, uint32_t b)
@@ -333,6 +333,24 @@ static inline int32_t substract_32_saturate(uint32_t a, uint32_t b)
 	return out;
 }
 
+// Multiply two S.31 fractional integers, and return the 32 most significant
+// bits after a shift left by the constant z.
+// This comes from rockbox.org
+
+static inline int32_t FRACMUL_SHL(int32_t x, int32_t y, int z)
+{
+    int32_t t, t2;
+    asm ("smull    %[t], %[t2], %[a], %[b]\n\t"
+         "mov      %[t2], %[t2], asl %[c]\n\t"
+         "orr      %[t], %[t2], %[t], lsr %[d]\n\t"
+         : [t] "=&r" (t), [t2] "=&r" (t2)
+         : [a] "r" (x), [b] "r" (y),
+           [c] "Mr" ((z) + 1), [d] "Mr" (31 - (z)));
+    return t;
+}
+
+#endif
+
 //get Q from PSR
 static inline uint32_t get_q_psr(void) __attribute__((always_inline, unused));
 static inline uint32_t get_q_psr(void)
@@ -351,20 +369,5 @@ static inline void clr_q_psr(void)
        "msr APSR_nzcvq,%0\n" : [t] "=&r" (t)::"cc");
 }
 
-// Multiply two S.31 fractional integers, and return the 32 most significant
-// bits after a shift left by the constant z.
-// This comes from rockbox.org
-
-static inline int32_t FRACMUL_SHL(int32_t x, int32_t y, int z)
-{
-    int32_t t, t2;
-    asm ("smull    %[t], %[t2], %[a], %[b]\n\t"
-         "mov      %[t2], %[t2], asl %[c]\n\t"
-         "orr      %[t], %[t2], %[t], lsr %[d]\n\t"
-         : [t] "=&r" (t), [t2] "=&r" (t2)
-         : [a] "r" (x), [b] "r" (y),
-           [c] "Mr" ((z) + 1), [d] "Mr" (31 - (z)));
-    return t;
-}
 
 #endif


### PR DESCRIPTION
Quick fixes to avoid compilation errors.

Needed for Blocksize=128.  
Blocksize 128 is needed for the waveplayer.