### PR TITLE
Pdm teensy4  - add support for T4 / IMXRT1062 to PDM input

### DIFF
--- a/Audio.h
+++ b/Audio.h
@@ -101,6 +101,7 @@
 #include "input_tdm.h"
 #include "input_tdm2.h"
 #include "input_pdm.h"
+#include "input_pdm_i2s2.h"
 #include "input_spdif3.h"
 #include "mixer.h"
 #include "output_dac.h"

--- a/gui/index.html
+++ b/gui/index.html
@@ -379,9 +379,12 @@ span.mainfunction {color: #993300; font-weight: bolder}
 		{"type":"AudioInputAnalogStereo","resource":"ADC1",          "shareable":false},
 		{"type":"AudioInputAnalogStereo","resource":"ADC2",          "shareable":false},
 		{"type":"AudioInputAnalogStereo","resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
-		{"type":"AudioInputPDM",         "resource":"I2S Device",    "shareable":true,  "setting":"PDM Protocol"},
+		{"type":"AudioInputPDM",         "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
 		{"type":"AudioInputPDM",         "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
 		{"type":"AudioInputPDM",         "resource":"IN1 Pin",       "shareable":false},
+		{"type":"AudioInputPDM2",        "resource":"I2S2 Device",   "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioInputPDM2",        "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputPDM2",        "resource":"IN2 Pin",       "shareable":false},
 		{"type":"AudioInputTDM",         "resource":"I2S Device",    "shareable":true,  "setting":"TDM Protocol"},
 		{"type":"AudioInputTDM",         "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
 		{"type":"AudioInputTDM",         "resource":"IN1 Pin",       "shareable":false},
@@ -464,6 +467,7 @@ span.mainfunction {color: #993300; font-weight: bolder}
 		{"type":"AudioInputAnalog","data":{"defaults":{"name":{"value":"new"}},"shortName":"adc","inputs":0,"outputs":1,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioInputAnalogStereo","data":{"defaults":{"name":{"value":"new"}},"shortName":"adcs","inputs":0,"outputs":2,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioInputPDM","data":{"defaults":{"name":{"value":"new"}},"shortName":"pdm","inputs":0,"outputs":1,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputPDM2","data":{"defaults":{"name":{"value":"new"}},"shortName":"pdm2","inputs":0,"outputs":1,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioInputTDM","data":{"defaults":{"name":{"value":"new"}},"shortName":"tdm","inputs":0,"outputs":16,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioInputTDM2","data":{"defaults":{"name":{"value":"new"}},"shortName":"tdm2","inputs":0,"outputs":16,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioInputUSB","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb","inputs":0,"outputs":2,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
@@ -1326,9 +1330,9 @@ Returns the actual achieved attenuation of the anti-aliasing filter. If the inpu
 		Adafruit MP34DT01-M Microphone Board</a>.
 	</p>
 	<table class=doc align=center cellpadding=3>
-		<tr class=top><th>T3.x Pin</th><th>T4.x Pin I2S1</th><th>T4.x Pin I2S2</th><th>Signal</th><th>Direction</th></tr>
-		<tr class=odd><td align=center>9</td><td align=center>21</td><td align=center>4</td><td>CLK</td><td>Output, 2.8235 MHz</td></tr>
-		<tr class=odd><td align=center>13</td><td align=center>8</td><td align=center>5</td><td>DATA</td><td>Input, Data on rising edge</td></tr>
+		<tr class=top><th>T3.x Pin</th><th>T4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td>CLK</td><td>Output, 2.8235 MHz</td></tr>
+		<tr class=odd><td align=center>13</td><td align=center>8</td><td>DATA</td><td>Input, Data on rising edge</td></tr>
 	</table>
 
 	<p>Data is input on the rising edge.  The SEL pin on MP34DT01-M should be
@@ -1351,6 +1355,60 @@ Returns the actual achieved attenuation of the anti-aliasing filter. If the inpu
 		</p>
 </script>
 <script type="text/x-red" data-template-name="AudioInputPDM">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+
+<script type="text/x-red" data-help-name="AudioInputPDM2">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive (and filter) a Pulse Density Modulated bitstream from I2S2 unit.
+		</p>
+	<p align=center><img src="img/pdmmic.jpg"><br><small>PDM MEMS Mic, using I2S2</small></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Filtered Audio Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the PDM data, filters out the high frequency
+		noise and gives you the audio signal.</p>
+	<h3>Hardware</h3>
+	<p>PDM2 has been tested with this <a href="https://www.adafruit.com/product/3492">
+		Adafruit MP34DT01-M Microphone Board</a>.
+	</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T4.x Pin I2S2</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>4</td><td>CLK</td><td>Output, 2.8235 MHz</td></tr>
+		<tr class=odd><td align=center>5</td><td>DATA</td><td>Input, Data on rising edge</td></tr>
+	</table>
+
+	<p>Data is input on the rising edge.  The SEL pin on MP34DT01-M should be
+		connected LOW for proper data capture.</p>
+	<!--<h3>Examples</h3>-->
+	<h3>Notes</h3>
+        <p>This uses the alternate I2S2 unit on the T4, employing the BCLK2 and IN2 pins, 
+	   allowing AudioInputI2S to be run alongside.</p>
+	<p>The filter used is a 512 tap FIR with approx &plusmn;1.1 dB gain
+		flatness to 10 kHz.  While far from audiophile grade, this should
+		perform far better than the rapid rolloff of Cascaded Integrator
+		Comb (CIC) or simple moving average filters commonly used on
+		other microcontrollers.  The filter also consumes 2104 bytes of
+		RAM for buffering and 32K of Flash for a lookup table to optimized
+		the filter computation.
+		</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputPDM2">
 	<div class="form-row">
 		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
 		<input type="text" id="node-input-name" placeholder="Name">

--- a/gui/index.html
+++ b/gui/index.html
@@ -1309,8 +1309,8 @@ Returns the actual achieved attenuation of the anti-aliasing filter. If the inpu
 	<li>Teensy 3.2
 	<li>Teensy 3.5
 	<li>Teensy 3.6
-	<!--<li>Teensy 4.0
-	<li>Teensy 4.1-->
+	<li>Teensy 4.0
+	<li>Teensy 4.1
 	</ul>
 	<h3>Audio Connections</h3>
 	<table class=doc align=center cellpadding=3>
@@ -1324,20 +1324,22 @@ Returns the actual achieved attenuation of the anti-aliasing filter. If the inpu
 	<h3>Hardware</h3>
 	<p>PDM has been tested with this <a href="https://www.adafruit.com/product/3492">
 		Adafruit MP34DT01-M Microphone Board</a>.
-		</p>
+	</p>
 	<table class=doc align=center cellpadding=3>
-		<tr class=top><th>Pin</th><th>Signal</th><th>Direction</th></tr>
-		<tr class=odd><td align=center>9</td><td>CLK</td><td>Output, 2.8235 MHz</td></tr>
-		<tr class=odd><td align=center>13</td><td>DATA</td><td>Input, Data on rising edge</td></tr>
+		<tr class=top><th>T3.x Pin</th><th>T4.x Pin I2S1</th><th>T4.x Pin I2S2</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td align=center>4</td><td>CLK</td><td>Output, 2.8235 MHz</td></tr>
+		<tr class=odd><td align=center>13</td><td align=center>8</td><td align=center>5</td><td>DATA</td><td>Input, Data on rising edge</td></tr>
 	</table>
+
 	<p>Data is input on the rising edge.  The SEL pin on MP34DT01-M should be
 		connected LOW for proper data capture.</p>
 	<!--<h3>Examples</h3>-->
 	<h3>Notes</h3>
-	<p>Filtering consumes approximately 39% of the CPU when running at
+	<p>On the T3 filtering consumes approximately 39% of the CPU when running at
 		96 MHz.  The code currently consumes this time inside a high
 		priority interrupt, blocking other libraries.  Perhaps future
-		versions will perform filtering at lower priority.
+	  versions will perform filtering at lower priority.  The CPU usage is less
+	  burdensome for the T4.
 		</p>
 	<p>The filter used is a 512 tap FIR with approx &plusmn;1.1 dB gain
 		flatness to 10 kHz.  While far from audiophile grade, this should

--- a/input_pdm.cpp
+++ b/input_pdm.cpp
@@ -122,7 +122,7 @@ void AudioInputPDM::begin(bool use_i2s2)
   }
   else
   {
-    AudioOutputI2S::config_i2s() ;
+    AudioOutputI2S::config_i2s(true) ;
     int rsync = 0;
     int tsync = 1;
     /*
@@ -274,6 +274,8 @@ void AudioInputPDM::begin(void)
 {
 	dma.begin(true); // Allocate the DMA channel first
 
+	AudioOutputI2S::config_i2s(true);
+	/*
 	SIM_SCGC6 |= SIM_SCGC6_I2S;
 	SIM_SCGC7 |= SIM_SCGC7_DMA;
 	SIM_SCGC6 |= SIM_SCGC6_DMAMUX;
@@ -295,18 +297,23 @@ void AudioInputPDM::begin(void)
 
         // configure receiver (sync'd to transmitter clocks)
         I2S0_RMR = 0;
+	*/
         I2S0_RCR1 = I2S_RCR1_RFW(2);
+	/*
         I2S0_RCR2 = I2S_RCR2_SYNC(1) | I2S_TCR2_BCP | I2S_RCR2_MSEL(1)
                 | I2S_RCR2_BCD | I2S_RCR2_DIV(1);
         I2S0_RCR3 = I2S_RCR3_RCE;
+	*/
         I2S0_RCR4 = I2S_RCR4_FRSZ(1) | I2S_RCR4_SYWD(31) | I2S_RCR4_MF
                 /* | I2S_RCR4_FSE */ | I2S_RCR4_FSP | I2S_RCR4_FSD;
+	/*
         I2S0_RCR5 = I2S_RCR5_WNW(31) | I2S_RCR5_W0W(31) | I2S_RCR5_FBT(31);
 
         CORE_PIN9_CONFIG  = PORT_PCR_MUX(6); // pin  9, PTC3, I2S0_TX_BCLK
-	CORE_PIN13_CONFIG = PORT_PCR_MUX(4); // pin 13, PTC5, I2S0_RXD0
-
+	*/
+	
 #if defined(KINETISK)
+	CORE_PIN13_CONFIG = PORT_PCR_MUX(4); // pin 13, PTC5, I2S0_RXD0
 	dma.TCD->SADDR = &I2S0_RDR0;
 	dma.TCD->SOFF = 0;
 	dma.TCD->ATTR = DMA_TCD_ATTR_SSIZE(2) | DMA_TCD_ATTR_DSIZE(2);

--- a/input_pdm.cpp
+++ b/input_pdm.cpp
@@ -352,7 +352,7 @@ void AudioInputPDM::isr(void)
 	const uint32_t *src;
 	audio_block_t *left;
 
-	//digitalWriteFast(3, HIGH);
+	//digitalWriteFast(14, HIGH);
 #if defined(KINETISK) || defined(__IMXRT1052__) || defined(__IMXRT1062__)
 	daddr = (uint32_t)(dma.TCD->DADDR);
 	dma.clearInterrupt();
@@ -388,7 +388,7 @@ void AudioInputPDM::isr(void)
 		//left->data[0] = 0x7FFF;
 	}
 #endif
-	//digitalWriteFast(3, LOW);
+	//digitalWriteFast(14, LOW);
 }
 
 void AudioInputPDM::update(void)

--- a/input_pdm.cpp
+++ b/input_pdm.cpp
@@ -24,8 +24,7 @@
  * THE SOFTWARE.
  */
 
-#if defined(KINETISK)
- 
+
 #include <Arduino.h>
 #include "input_pdm.h"
 #include "utility/dspinst.h"
@@ -57,6 +56,99 @@ static uint32_t leftover[14];
 audio_block_t * AudioInputPDM::block_left = NULL;
 bool AudioInputPDM::update_responsibility = false;
 DMAChannel AudioInputPDM::dma(false);
+
+
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
+
+#include "utility/imxrt_hw.h"
+
+// T4.x version
+void AudioInputPDM::begin(void)
+{
+  dma.begin(true); // Allocate the DMA channel first
+
+  CCM_CCGR5 |= CCM_CCGR5_SAI1(CCM_CCGR_ON);
+
+//PLL:
+  int fs = AUDIO_SAMPLE_RATE_EXACT;
+  // PLL between 27*24 = 648MHz und 54*24=1296MHz
+  int n1 = 4; //SAI prescaler 4 => (n1*n2) = multiple of 4
+  int n2 = 1 + (24000000 * 27) / (fs * 256 * n1);
+
+  double C = ((double)fs * 256 * n1 * n2) / 24000000;
+  int c0 = C;
+  int c2 = 10000;
+  int c1 = C * c2 - (c0 * c2);
+  set_audioClock(c0, c1, c2);
+
+  // clear SAI1_CLK register locations
+  CCM_CSCMR1 = (CCM_CSCMR1 & ~(CCM_CSCMR1_SAI1_CLK_SEL_MASK))
+    | CCM_CSCMR1_SAI1_CLK_SEL(2); // &0x03 // (0,1,2): PLL3PFD0, PLL5, PLL4
+  CCM_CS1CDR = (CCM_CS1CDR & ~(CCM_CS1CDR_SAI1_CLK_PRED_MASK | CCM_CS1CDR_SAI1_CLK_PODF_MASK))
+    | CCM_CS1CDR_SAI1_CLK_PRED(n1-1) // &0x07
+    | CCM_CS1CDR_SAI1_CLK_PODF(n2-1); // &0x3f
+
+  // Select MCLK
+  IOMUXC_GPR_GPR1 = (IOMUXC_GPR_GPR1 & ~(IOMUXC_GPR_GPR1_SAI1_MCLK1_SEL_MASK))
+    | (IOMUXC_GPR_GPR1_SAI1_MCLK_DIR | IOMUXC_GPR_GPR1_SAI1_MCLK1_SEL(0));
+  /*
+  //// CORE_PIN33_CONFIG = 3;  //1:MCLK
+  CORE_PIN4_CONFIG = 3;  //1:RX_BCLK
+  //// CORE_PIN3_CONFIG = 3;  //1:RX_SYNC  // LRCLK
+  */
+  //// CORE_PIN23_CONFIG = 3;  //1:MCLK
+  CORE_PIN21_CONFIG = 3;  //1:RX_BCLK
+  //// CORE_PIN20_CONFIG = 3;  //1:RX_SYNC  // LRCLK
+  
+  int rsync = 0;
+  int tsync = 1;
+
+  I2S1_TMR = 0;
+  //I2S1_TCSR = (1<<25); //Reset
+  I2S1_TCR1 = I2S_TCR1_RFW(1);
+  I2S1_TCR2 = I2S_TCR2_SYNC(tsync) | I2S_TCR2_BCP | (I2S_TCR2_BCD | I2S_TCR2_DIV((1)) | I2S_TCR2_MSEL(1)); // sync=0; tx is async;
+  I2S1_TCR3 = I2S_TCR3_TCE;
+  I2S1_TCR4 = I2S_TCR4_FRSZ((2-1)) | I2S_TCR4_SYWD((32-1)) | I2S_TCR4_MF | I2S_TCR4_FSD | I2S_TCR4_FSE | I2S_TCR4_FSP;
+  I2S1_TCR5 = I2S_TCR5_WNW((32-1)) | I2S_TCR5_W0W((32-1)) | I2S_TCR5_FBT((32-1));
+
+  I2S1_RMR = 0;
+  //I2S1_RCSR = (1<<25); //Reset
+  I2S1_RCR1 = I2S_RCR1_RFW(2);
+  I2S1_RCR2 = I2S_RCR2_SYNC(rsync) | I2S_RCR2_BCP | (I2S_RCR2_BCD | I2S_RCR2_DIV((1)) | I2S_RCR2_MSEL(1));  // sync=0; rx is async;
+  I2S1_RCR3 = I2S_RCR3_RCE;
+  I2S1_RCR4 = I2S_RCR4_FRSZ((2-1)) | I2S_RCR4_SYWD((32-1)) | I2S_RCR4_MF /* | I2S_RCR4_FSE */ | I2S_RCR4_FSP | I2S_RCR4_FSD;
+  I2S1_RCR5 = I2S_RCR5_WNW((32-1)) | I2S_RCR5_W0W((32-1)) | I2S_RCR5_FBT((32-1));
+
+  /*
+  CORE_PIN5_CONFIG  = 3;  //1:RX_DATA0
+  */
+  CORE_PIN8_CONFIG  = 3;  //1:RX_DATA0
+
+  IOMUXC_SAI1_RX_DATA0_SELECT_INPUT = 2;
+  
+  dma.TCD->SADDR = &I2S1_RDR0;
+  dma.TCD->SOFF = 0;
+  dma.TCD->ATTR = DMA_TCD_ATTR_SSIZE(2) | DMA_TCD_ATTR_DSIZE(2);
+  dma.TCD->NBYTES_MLNO = 4;
+  dma.TCD->SLAST = 0;
+  dma.TCD->DADDR = pdm_buffer;
+  dma.TCD->DOFF = 4;
+  dma.TCD->CITER_ELINKNO = sizeof(pdm_buffer) / 4;
+  dma.TCD->DLASTSGA = -sizeof(pdm_buffer);
+  dma.TCD->BITER_ELINKNO = sizeof(pdm_buffer) / 4;
+  dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+
+  dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
+  update_responsibility = update_setup();
+  dma.enable();
+
+  I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
+  I2S1_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
+
+  dma.attachInterrupt(isr);
+}
+
+#else  // not T4:
 
 // MCLK needs to be 48e6 / 1088 * 256 = 11.29411765 MHz -> 44.117647 kHz sample rate
 //
@@ -110,6 +202,7 @@ DMAChannel AudioInputPDM::dma(false);
 #endif
 #endif
 
+// T3.x version
 void AudioInputPDM::begin(void)
 {
 	dma.begin(true); // Allocate the DMA channel first
@@ -167,6 +260,7 @@ void AudioInputPDM::begin(void)
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
 	dma.attachInterrupt(isr);
 }
+#endif
 
 extern const int16_t enormous_pdm_filter_table[16384];
 
@@ -255,9 +349,8 @@ void AudioInputPDM::isr(void)
 	audio_block_t *left;
 
 	//digitalWriteFast(3, HIGH);
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__IMXRT1052__) || defined(__IMXRT1062__)
 	daddr = (uint32_t)(dma.TCD->DADDR);
-#endif
 	dma.clearInterrupt();
 
 	if (daddr < (uint32_t)pdm_buffer + sizeof(pdm_buffer) / 2) {
@@ -276,6 +369,9 @@ void AudioInputPDM::isr(void)
 		// the lower priority update.  This burns ~40% of the CPU
 		// time in a high priority interrupt.  Not ideal.  :(
 		int16_t *dest = left->data;
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
+		arm_dcache_delete ((void*) src, sizeof (pdm_buffer) >> 1);
+#endif
 		for (unsigned int i=0; i < 14; i += 2) {
 			*dest++ = filter(leftover + i, 7 - (i >> 1), src);
 		}
@@ -287,7 +383,8 @@ void AudioInputPDM::isr(void)
 		}
 		//left->data[0] = 0x7FFF;
 	}
-	//digitalWriteFast(3, LOW);
+#endif
+	//digitalWriteFast(14, LOW);
 }
 
 void AudioInputPDM::update(void)
@@ -1719,4 +1816,3 @@ for ($n=0; $n < 512; $n += 8) {
 print "\n};\n";
 print "// max=$max, min=$min\n";
 */
-#endif

--- a/input_pdm.cpp
+++ b/input_pdm.cpp
@@ -64,68 +64,14 @@ DMAChannel AudioInputPDM::dma(false);
 #include "utility/imxrt_hw.h"
 
 // T4.x version
-void AudioInputPDM::begin(bool use_i2s2)
+void AudioInputPDM::begin()
 {
   dma.begin(true); // Allocate the DMA channel first
 
-  if (use_i2s2)
-  {
-    CCM_CCGR5 |= CCM_CCGR5_SAI2(CCM_CCGR_ON);
-    //PLL:
-    int fs = AUDIO_SAMPLE_RATE_EXACT;
-    // PLL between 27*24 = 648MHz und 54*24=1296MHz
-    int n1 = 4; //SAI prescaler 4 => (n1*n2) = multiple of 4
-    int n2 = 1 + (24000000 * 27) / (fs * 256 * n1);
-
-    double C = ((double)fs * 256 * n1 * n2) / 24000000;
-    int c0 = C;
-    int c2 = 10000;
-    int c1 = C * c2 - (c0 * c2);
-    set_audioClock(c0, c1, c2);
-
-    int rsync = 0;
+  AudioOutputI2S::config_i2s(true) ;
+  int rsync = 0;
+  /*
     int tsync = 1;
-    // clear SAI2_CLK register locations
-    CCM_CSCMR1 = (CCM_CSCMR1 & ~(CCM_CSCMR1_SAI2_CLK_SEL_MASK))
-      | CCM_CSCMR1_SAI2_CLK_SEL(2); // &0x03 // (0,1,2): PLL3PFD0, PLL5, PLL4
-    CCM_CS2CDR = (CCM_CS2CDR & ~(CCM_CS2CDR_SAI2_CLK_PRED_MASK | CCM_CS2CDR_SAI2_CLK_PODF_MASK))
-      | CCM_CS2CDR_SAI2_CLK_PRED(n1-1) // &0x07
-      | CCM_CS2CDR_SAI2_CLK_PODF(n2-1); // &0x3f
-  
-    // Select MCLK - SAI2 doesn't seem to have write access to MCLK2, so use MCLK3 (not enabled as a pin anyway)
-    IOMUXC_GPR_GPR1 = (IOMUXC_GPR_GPR1 & ~(IOMUXC_GPR_GPR1_SAI2_MCLK3_SEL_MASK))
-    | (IOMUXC_GPR_GPR1_SAI2_MCLK_DIR | IOMUXC_GPR_GPR1_SAI2_MCLK3_SEL(0));
-
-    // all the pins for SAI2 seem to be ALT2 io-muxed
-    //// CORE_PIN33_CONFIG = 2;  //2:MCLK
-    CORE_PIN4_CONFIG = 2;  //2:TX_BCLK
-    //// CORE_PIN3_CONFIG = 2;  //2:RX_SYNC  // LRCLK
-
-    I2S2_TMR = 0;
-    //I2S2_TCSR = (1<<25); //Reset
-    I2S2_TCR1 = I2S_TCR1_RFW(1);
-    I2S2_TCR2 = I2S_TCR2_SYNC(tsync) | I2S_TCR2_BCP | (I2S_TCR2_BCD | I2S_TCR2_DIV((1)) | I2S_TCR2_MSEL(1)); // sync=0; tx is async;
-    I2S2_TCR3 = I2S_TCR3_TCE;
-    I2S2_TCR4 = I2S_TCR4_FRSZ((2-1)) | I2S_TCR4_SYWD((32-1)) | I2S_TCR4_MF | I2S_TCR4_FSD | I2S_TCR4_FSE | I2S_TCR4_FSP;
-    I2S2_TCR5 = I2S_TCR5_WNW((32-1)) | I2S_TCR5_W0W((32-1)) | I2S_TCR5_FBT((32-1));
-
-    I2S2_RMR = 0;
-    //I2S2_RCSR = (1<<25); //Reset
-    I2S2_RCR1 = I2S_RCR1_RFW(2);
-    I2S2_RCR2 = I2S_RCR2_SYNC(rsync) | I2S_RCR2_BCP | (I2S_RCR2_BCD | I2S_RCR2_DIV((1)) | I2S_RCR2_MSEL(1));  // sync=0; rx is async;
-    I2S2_RCR3 = I2S_RCR3_RCE;
-    I2S2_RCR4 = I2S_RCR4_FRSZ((2-1)) | I2S_RCR4_SYWD((32-1)) | I2S_RCR4_MF /* | I2S_RCR4_FSE */ | I2S_RCR4_FSP | I2S_RCR4_FSD;
-    I2S2_RCR5 = I2S_RCR5_WNW((32-1)) | I2S_RCR5_W0W((32-1)) | I2S_RCR5_FBT((32-1));
-
-    CORE_PIN5_CONFIG  = 2;  //2:RX_DATA0
-    IOMUXC_SAI2_RX_DATA0_SELECT_INPUT = 0;
-  }
-  else
-  {
-    AudioOutputI2S::config_i2s(true) ;
-    int rsync = 0;
-    int tsync = 1;
-    /*
     CCM_CCGR5 |= CCM_CCGR5_SAI1(CCM_CCGR_ON);
     //PLL:
     int fs = AUDIO_SAMPLE_RATE_EXACT;
@@ -163,25 +109,19 @@ void AudioInputPDM::begin(bool use_i2s2)
     I2S1_TCR3 = I2S_TCR3_TCE;
     I2S1_TCR4 = I2S_TCR4_FRSZ((2-1)) | I2S_TCR4_SYWD((32-1)) | I2S_TCR4_MF | I2S_TCR4_FSD | I2S_TCR4_FSE | I2S_TCR4_FSP;
     I2S1_TCR5 = I2S_TCR5_WNW((32-1)) | I2S_TCR5_W0W((32-1)) | I2S_TCR5_FBT((32-1));
-    */
-    I2S1_RMR = 0;
-    //I2S1_RCSR = (1<<25); //Reset
-    I2S1_RCR1 = I2S_RCR1_RFW(2);  // 2 not 1
-    I2S1_RCR2 = I2S_RCR2_SYNC(rsync) | I2S_RCR2_BCP | (I2S_RCR2_BCD | I2S_RCR2_DIV((1)) | I2S_RCR2_MSEL(1));  // sync=0; rx is async;
-    I2S1_RCR3 = I2S_RCR3_RCE;
-    I2S1_RCR4 = I2S_RCR4_FRSZ((2-1)) | I2S_RCR4_SYWD((32-1)) | I2S_RCR4_MF /* | I2S_RCR4_FSE */ | I2S_RCR4_FSP | I2S_RCR4_FSD;
-    I2S1_RCR5 = I2S_RCR5_WNW((32-1)) | I2S_RCR5_W0W((32-1)) | I2S_RCR5_FBT((32-1));
+  */
+  I2S1_RMR = 0;
+  //I2S1_RCSR = (1<<25); //Reset
+  I2S1_RCR1 = I2S_RCR1_RFW(2);  // 2 not 1
+  I2S1_RCR2 = I2S_RCR2_SYNC(rsync) | I2S_RCR2_BCP | (I2S_RCR2_BCD | I2S_RCR2_DIV((1)) | I2S_RCR2_MSEL(1));  // sync=0; rx is async;
+  I2S1_RCR3 = I2S_RCR3_RCE;
+  I2S1_RCR4 = I2S_RCR4_FRSZ((2-1)) | I2S_RCR4_SYWD((32-1)) | I2S_RCR4_MF /* | I2S_RCR4_FSE */ | I2S_RCR4_FSP | I2S_RCR4_FSD;
+  I2S1_RCR5 = I2S_RCR5_WNW((32-1)) | I2S_RCR5_W0W((32-1)) | I2S_RCR5_FBT((32-1));
 
+  CORE_PIN8_CONFIG  = 3;  //1:RX_DATA0
+  IOMUXC_SAI1_RX_DATA0_SELECT_INPUT = 2;
 
-    CORE_PIN8_CONFIG  = 3;  //1:RX_DATA0
-    IOMUXC_SAI1_RX_DATA0_SELECT_INPUT = 2;
-  }
-
-  
-  if (use_i2s2)
-    dma.TCD->SADDR = &I2S2_RDR0;
-  else
-    dma.TCD->SADDR = &I2S1_RDR0;
+  dma.TCD->SADDR = &I2S1_RDR0;
   dma.TCD->SOFF = 0;
   dma.TCD->ATTR = DMA_TCD_ATTR_SSIZE(2) | DMA_TCD_ATTR_DSIZE(2);
   dma.TCD->NBYTES_MLNO = 4;
@@ -193,25 +133,15 @@ void AudioInputPDM::begin(bool use_i2s2)
   dma.TCD->BITER_ELINKNO = sizeof(pdm_buffer) / 4;
   dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 
-  if (use_i2s2)
-    dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_RX);
-  else
-    dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
+  dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
   
   update_responsibility = update_setup();
   dma.enable();
 
-  if (use_i2s2)
-  {
-    I2S2_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
-    //I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
-  }
-  else
-  {
-    I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
-    //I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
-    //I2S1_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
-  }
+  I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
+  //I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
+  //I2S1_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
+
   dma.attachInterrupt(isr);
 }
 
@@ -336,9 +266,9 @@ void AudioInputPDM::begin(void)
 }
 #endif
 
-extern const int16_t enormous_pdm_filter_table[16384];
+extern const int16_t enormous_pdm_filter_table[];
 
-static int filter(const uint32_t *buf)
+int pdm_filter(const uint32_t *buf)
 {
 	const int16_t *table = enormous_pdm_filter_table;
 	int sum = 0;
@@ -366,7 +296,7 @@ static int filter(const uint32_t *buf)
 	return signed_saturate_rshift(sum, 16, RSHIFT);
 }
 
-static int filter(const uint32_t *buf1, unsigned int n, const uint32_t *buf2)
+int pdm_filter(const uint32_t *buf1, unsigned int n, const uint32_t *buf2)
 {
 	const int16_t *table = enormous_pdm_filter_table;
 	int sum = 0;
@@ -447,10 +377,10 @@ void AudioInputPDM::isr(void)
 		arm_dcache_delete ((void*) src, sizeof (pdm_buffer) >> 1);
 #endif
 		for (unsigned int i=0; i < 14; i += 2) {
-			*dest++ = filter(leftover + i, 7 - (i >> 1), src);
+			*dest++ = pdm_filter(leftover + i, 7 - (i >> 1), src);
 		}
 		for (unsigned int i=0; i < AUDIO_BLOCK_SAMPLES*2-14; i += 2) {
-			*dest++ = filter(src + i);
+			*dest++ = pdm_filter(src + i);
 		}
 		for (unsigned int i=0; i < 14; i++) {
 			leftover[i] = src[AUDIO_BLOCK_SAMPLES*2 - 14 + i];

--- a/input_pdm.h
+++ b/input_pdm.h
@@ -34,10 +34,22 @@
 class AudioInputPDM : public AudioStream
 {
 public:
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
+	AudioInputPDM(bool _use_i2s2) : AudioStream(0, NULL)
+        {
+	  begin(_use_i2s2);
+	}
+	AudioInputPDM(void) : AudioStream(0, NULL) { begin(false); }
+#else
 	AudioInputPDM(void) : AudioStream(0, NULL) { begin(); }
+#endif
 	virtual void update(void);
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
+	void begin(bool _use_i2s2);
+#else
 	void begin(void);
-protected:	
+#endif
+protected:
 	static bool update_responsibility;
 	static DMAChannel dma;
 	static void isr(void);

--- a/input_pdm_i2s2.cpp
+++ b/input_pdm_i2s2.cpp
@@ -1,0 +1,205 @@
+/* Audio Library for Teensy 3.X
+ * Copyright (c) 2018, Paul Stoffregen, paul@pjrc.com
+ *
+ * Development of this audio library was funded by PJRC.COM, LLC by sales of
+ * Teensy and Audio Adaptor boards.  Please support PJRC's efforts to develop
+ * open source software by purchasing Teensy or other PJRC products.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice, development funding notice, and this permission
+ * notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#include <Arduino.h>
+#include "input_pdm_i2s2.h"
+#include "utility/dspinst.h"
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
+#  include "utility/imxrt_hw.h"
+#endif
+
+// Decrease this for more mic gain, increase for range to accommodate loud sounds
+#define RSHIFT  2
+
+// Pulse Density Modulation (PDM) is a tech trade-off of questionable value.
+// The only advantage is your delta-sigma based ADC can be less expensive,
+// since it can omit the digital low-pass filter.  But it limits the ADC
+// to a single bit modulator, and it imposes the filtering requirement onto
+// your microcontroller.  Generally digital filtering is much less expensive
+// to implement with dedicated digital logic than firmware in a general
+// purpose microcontroller.  PDM probably makes more sense with an ASIC or
+// highly integrated SoC, or maybe even with a "real" DSP chip.  Using a
+// microcontroller, maybe not so much?
+//
+// This code imposes considerable costs.  It consumes 39% of the CPU time
+// when running at 96 MHz, and uses 2104 bytes of RAM for buffering and 32768
+// bytes of flash for a large table lookup to optimize the filter computation.
+//
+// On the plus side, this filter is a 512 tap FIR with approximately +/- 1 dB
+// gain flatness to 10 kHz bandwidth.  That won't impress any audio enthusiasts,
+// but its performance should be *much* better than the rapid passband rolloff
+// of Cascaded Integrator Comb (CIC) or moving average filters.
+
+DMAMEM __attribute__((aligned(32))) static uint32_t pdm_buffer[AUDIO_BLOCK_SAMPLES*4];
+static uint32_t leftover[14];
+audio_block_t * AudioInputPDM2::block_left = NULL;
+bool AudioInputPDM2::update_responsibility = false;
+DMAChannel AudioInputPDM2::dma(false);
+
+
+
+
+// T4.x version
+void AudioInputPDM2::begin(void)
+{
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
+  dma.begin(true); // Allocate the DMA channel first
+
+  CCM_CCGR5 |= CCM_CCGR5_SAI2(CCM_CCGR_ON);
+  //PLL:
+  int fs = AUDIO_SAMPLE_RATE_EXACT;
+  // PLL between 27*24 = 648MHz und 54*24=1296MHz
+  int n1 = 4; //SAI prescaler 4 => (n1*n2) = multiple of 4
+  int n2 = 1 + (24000000 * 27) / (fs * 256 * n1);
+
+  double C = ((double)fs * 256 * n1 * n2) / 24000000;
+  int c0 = C;
+  int c2 = 10000;
+  int c1 = C * c2 - (c0 * c2);
+  set_audioClock(c0, c1, c2);
+
+  int rsync = 0;
+  int tsync = 1;
+  // clear SAI2_CLK register locations
+  CCM_CSCMR1 = (CCM_CSCMR1 & ~(CCM_CSCMR1_SAI2_CLK_SEL_MASK))
+    | CCM_CSCMR1_SAI2_CLK_SEL(2); // &0x03 // (0,1,2): PLL3PFD0, PLL5, PLL4
+  CCM_CS2CDR = (CCM_CS2CDR & ~(CCM_CS2CDR_SAI2_CLK_PRED_MASK | CCM_CS2CDR_SAI2_CLK_PODF_MASK))
+    | CCM_CS2CDR_SAI2_CLK_PRED(n1-1) // &0x07
+    | CCM_CS2CDR_SAI2_CLK_PODF(n2-1); // &0x3f
+  
+  // Select MCLK - SAI2 doesn't seem to have write access to MCLK2, so use MCLK3 (not enabled as a pin anyway)
+  IOMUXC_GPR_GPR1 = (IOMUXC_GPR_GPR1 & ~(IOMUXC_GPR_GPR1_SAI2_MCLK3_SEL_MASK))
+    | (IOMUXC_GPR_GPR1_SAI2_MCLK_DIR | IOMUXC_GPR_GPR1_SAI2_MCLK3_SEL(0));
+
+  // all the pins for SAI2 seem to be ALT2 io-muxed
+  //// CORE_PIN33_CONFIG = 2;  //2:MCLK
+  CORE_PIN4_CONFIG = 2;  //2:TX_BCLK
+  //// CORE_PIN3_CONFIG = 2;  //2:RX_SYNC  // LRCLK
+
+  I2S2_TMR = 0;
+  //I2S2_TCSR = (1<<25); //Reset
+  I2S2_TCR1 = I2S_TCR1_RFW(1);
+  I2S2_TCR2 = I2S_TCR2_SYNC(tsync) | I2S_TCR2_BCP | (I2S_TCR2_BCD | I2S_TCR2_DIV((1)) | I2S_TCR2_MSEL(1)); // sync=0; tx is async;
+  I2S2_TCR3 = I2S_TCR3_TCE;
+  I2S2_TCR4 = I2S_TCR4_FRSZ((2-1)) | I2S_TCR4_SYWD((32-1)) | I2S_TCR4_MF | I2S_TCR4_FSD | I2S_TCR4_FSE | I2S_TCR4_FSP;
+  I2S2_TCR5 = I2S_TCR5_WNW((32-1)) | I2S_TCR5_W0W((32-1)) | I2S_TCR5_FBT((32-1));
+
+  I2S2_RMR = 0;
+  //I2S2_RCSR = (1<<25); //Reset
+  I2S2_RCR1 = I2S_RCR1_RFW(2);
+  I2S2_RCR2 = I2S_RCR2_SYNC(rsync) | I2S_RCR2_BCP | (I2S_RCR2_BCD | I2S_RCR2_DIV((1)) | I2S_RCR2_MSEL(1));  // sync=0; rx is async;
+  I2S2_RCR3 = I2S_RCR3_RCE;
+  I2S2_RCR4 = I2S_RCR4_FRSZ((2-1)) | I2S_RCR4_SYWD((32-1)) | I2S_RCR4_MF /* | I2S_RCR4_FSE */ | I2S_RCR4_FSP | I2S_RCR4_FSD;
+  I2S2_RCR5 = I2S_RCR5_WNW((32-1)) | I2S_RCR5_W0W((32-1)) | I2S_RCR5_FBT((32-1));
+
+  CORE_PIN5_CONFIG  = 2;  //2:RX_DATA0
+  IOMUXC_SAI2_RX_DATA0_SELECT_INPUT = 0;
+  
+  dma.TCD->SADDR = &I2S2_RDR0;
+  dma.TCD->SOFF = 0;
+  dma.TCD->ATTR = DMA_TCD_ATTR_SSIZE(2) | DMA_TCD_ATTR_DSIZE(2);
+  dma.TCD->NBYTES_MLNO = 4;
+  dma.TCD->SLAST = 0;
+  dma.TCD->DADDR = pdm_buffer;
+  dma.TCD->DOFF = 4;
+  dma.TCD->CITER_ELINKNO = sizeof(pdm_buffer) / 4;
+  dma.TCD->DLASTSGA = -sizeof(pdm_buffer);
+  dma.TCD->BITER_ELINKNO = sizeof(pdm_buffer) / 4;
+  dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+
+  dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_RX);
+  update_responsibility = update_setup();
+  dma.enable();
+
+  I2S2_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
+
+  dma.attachInterrupt(isr);
+#endif
+}
+
+extern const int16_t enormous_pdm_filter_table[];
+
+extern int pdm_filter(const uint32_t *buf);
+extern int pdm_filter(const uint32_t *buf1, unsigned int n, const uint32_t *buf2);
+
+void AudioInputPDM2::isr(void)
+{
+	uint32_t daddr;
+	const uint32_t *src;
+	audio_block_t *left;
+
+	//digitalWriteFast(14, HIGH);
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
+	daddr = (uint32_t)(dma.TCD->DADDR);
+	dma.clearInterrupt();
+
+	if (daddr < (uint32_t)pdm_buffer + sizeof(pdm_buffer) / 2) {
+		// DMA is receiving to the first half of the buffer
+		// need to remove data from the second half
+		src = pdm_buffer + AUDIO_BLOCK_SAMPLES*2;
+	} else {
+		// DMA is receiving to the second half of the buffer
+		// need to remove data from the first half
+		src = pdm_buffer;
+	}
+	if (update_responsibility) AudioStream::update_all();
+	left = block_left;
+	if (left != NULL) {
+		// TODO: should find a way to pass the unfiltered data to
+		// the lower priority update.  This burns ~40% of the CPU
+		// time in a high priority interrupt.  Not ideal.  :(
+		int16_t *dest = left->data;
+		arm_dcache_delete ((void*) src, sizeof (pdm_buffer) >> 1);
+		for (unsigned int i=0; i < 14; i += 2) {
+			*dest++ = pdm_filter(leftover + i, 7 - (i >> 1), src);
+		}
+		for (unsigned int i=0; i < AUDIO_BLOCK_SAMPLES*2-14; i += 2) {
+			*dest++ = pdm_filter(src + i);
+		}
+		for (unsigned int i=0; i < 14; i++) {
+			leftover[i] = src[AUDIO_BLOCK_SAMPLES*2 - 14 + i];
+		}
+		//left->data[0] = 0x7FFF;
+	}
+#endif
+	//digitalWriteFast(14, LOW);
+}
+
+void AudioInputPDM2::update(void)
+{
+	audio_block_t *new_left, *out_left;
+	new_left = allocate();
+	__disable_irq();
+	out_left = block_left;
+	block_left = new_left;
+	__enable_irq();
+	if (out_left) {
+		transmit(out_left, 0);
+		release(out_left);
+	}
+}
+

--- a/input_pdm_i2s2.cpp
+++ b/input_pdm_i2s2.cpp
@@ -24,13 +24,13 @@
  * THE SOFTWARE.
  */
 
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
 
 #include <Arduino.h>
 #include "input_pdm_i2s2.h"
 #include "utility/dspinst.h"
-#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
-#  include "utility/imxrt_hw.h"
-#endif
+#include "utility/imxrt_hw.h"
+
 
 // Decrease this for more mic gain, increase for range to accommodate loud sounds
 #define RSHIFT  2
@@ -66,7 +66,6 @@ DMAChannel AudioInputPDM2::dma(false);
 // T4.x version
 void AudioInputPDM2::begin(void)
 {
-#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
   dma.begin(true); // Allocate the DMA channel first
 
   CCM_CCGR5 |= CCM_CCGR5_SAI2(CCM_CCGR_ON);
@@ -138,7 +137,6 @@ void AudioInputPDM2::begin(void)
   I2S2_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 
   dma.attachInterrupt(isr);
-#endif
 }
 
 extern const int16_t enormous_pdm_filter_table[];
@@ -153,7 +151,6 @@ void AudioInputPDM2::isr(void)
 	audio_block_t *left;
 
 	//digitalWriteFast(14, HIGH);
-#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
 	daddr = (uint32_t)(dma.TCD->DADDR);
 	dma.clearInterrupt();
 
@@ -185,7 +182,6 @@ void AudioInputPDM2::isr(void)
 		}
 		//left->data[0] = 0x7FFF;
 	}
-#endif
 	//digitalWriteFast(14, LOW);
 }
 
@@ -203,3 +199,4 @@ void AudioInputPDM2::update(void)
 	}
 }
 
+#endif

--- a/input_pdm_i2s2.h
+++ b/input_pdm_i2s2.h
@@ -24,21 +24,20 @@
  * THE SOFTWARE.
  */
 
-#ifndef _input_pdm_h_
-#define _input_pdm_h_
+#ifndef _input_pdm_i2s2_h_
+#define _input_pdm_i2s2_h_
 
 #include "Arduino.h"
 #include "AudioStream.h"
 #include "DMAChannel.h"
 
-class AudioInputPDM : public AudioStream
+class AudioInputPDM2 : public AudioStream
 {
 public:
-	AudioInputPDM(void) : AudioStream(0, NULL) { begin(); }
+	AudioInputPDM2(void) : AudioStream(0, NULL) { begin(); }
 
 	virtual void update(void);
 	void begin(void);
-
 protected:
 	static bool update_responsibility;
 	static DMAChannel dma;

--- a/output_i2s.cpp
+++ b/output_i2s.cpp
@@ -337,7 +337,7 @@ void AudioOutputI2S::update(void)
 #endif
 
 
-void AudioOutputI2S::config_i2s(void)
+void AudioOutputI2S::config_i2s(bool only_bclk = false)
 {
 #if defined(KINETISK)
 	SIM_SCGC6 |= SIM_SCGC6_I2S;
@@ -345,8 +345,15 @@ void AudioOutputI2S::config_i2s(void)
 	SIM_SCGC6 |= SIM_SCGC6_DMAMUX;
 
 	// if either transmitter or receiver is enabled, do nothing
-	if (I2S0_TCSR & I2S_TCSR_TE) return;
-	if (I2S0_RCSR & I2S_RCSR_RE) return;
+	if ((I2S0_TCSR & I2S_TCSR_TE) != 0 || (I2S0_RCSR & I2S_RCSR_RE) != 0)
+	{
+	  if (!only_bclk) // if previous transmitter/receiver only activated BCLK, activate the other clock pins now
+	  {
+	    CORE_PIN23_CONFIG = PORT_PCR_MUX(6); // pin 23, PTC2, I2S0_TX_FS (LRCLK)
+	    CORE_PIN11_CONFIG = PORT_PCR_MUX(6); // pin 11, PTC6, I2S0_MCLK
+	  }
+	  return ;
+	}
 
 	// enable MCLK output
 	I2S0_MCR = I2S_MCR_MICS(MCLK_SRC) | I2S_MCR_MOE;
@@ -374,18 +381,29 @@ void AudioOutputI2S::config_i2s(void)
 	I2S0_RCR5 = I2S_RCR5_WNW(31) | I2S_RCR5_W0W(31) | I2S_RCR5_FBT(31);
 
 	// configure pin mux for 3 clock signals
-	CORE_PIN23_CONFIG = PORT_PCR_MUX(6); // pin 23, PTC2, I2S0_TX_FS (LRCLK)
+	if (!only_bclk)
+	{
+	  CORE_PIN23_CONFIG = PORT_PCR_MUX(6); // pin 23, PTC2, I2S0_TX_FS (LRCLK)
+	  CORE_PIN11_CONFIG = PORT_PCR_MUX(6); // pin 11, PTC6, I2S0_MCLK
+	}
 	CORE_PIN9_CONFIG  = PORT_PCR_MUX(6); // pin  9, PTC3, I2S0_TX_BCLK
-	CORE_PIN11_CONFIG = PORT_PCR_MUX(6); // pin 11, PTC6, I2S0_MCLK
 
 #elif defined(__IMXRT1062__)
 
 	CCM_CCGR5 |= CCM_CCGR5_SAI1(CCM_CCGR_ON);
 
 	// if either transmitter or receiver is enabled, do nothing
-	if (I2S1_TCSR & I2S_TCSR_TE) return;
-	if (I2S1_RCSR & I2S_RCSR_RE) return;
-//PLL:
+	if ((I2S1_TCSR & I2S_TCSR_TE) != 0 || (I2S1_RCSR & I2S_RCSR_RE) != 0)
+	{
+	  if (!only_bclk) // if previous transmitter/receiver only activated BCLK, activate the other clock pins now
+	  {
+	    CORE_PIN23_CONFIG = 3;  //1:MCLK
+	    CORE_PIN20_CONFIG = 3;  //1:RX_SYNC (LRCLK)
+	  }
+	  return ;
+	}
+
+	//PLL:
 	int fs = AUDIO_SAMPLE_RATE_EXACT;
 	// PLL between 27*24 = 648MHz und 54*24=1296MHz
 	int n1 = 4; //SAI prescaler 4 => (n1*n2) = multiple of 4
@@ -409,9 +427,12 @@ void AudioOutputI2S::config_i2s(void)
 		& ~(IOMUXC_GPR_GPR1_SAI1_MCLK1_SEL_MASK))
 		| (IOMUXC_GPR_GPR1_SAI1_MCLK_DIR | IOMUXC_GPR_GPR1_SAI1_MCLK1_SEL(0));
 
-	CORE_PIN23_CONFIG = 3;  //1:MCLK
+	if (!only_bclk)
+	{
+	  CORE_PIN23_CONFIG = 3;  //1:MCLK
+	  CORE_PIN20_CONFIG = 3;  //1:RX_SYNC  (LRCLK)
+	}
 	CORE_PIN21_CONFIG = 3;  //1:RX_BCLK
-	CORE_PIN20_CONFIG = 3;  //1:RX_SYNC
 
 	int rsync = 0;
 	int tsync = 1;

--- a/output_i2s.h
+++ b/output_i2s.h
@@ -48,6 +48,7 @@ public:
 	friend class AudioInputI2SHex;
 	friend class AudioOutputI2SOct;
 	friend class AudioInputI2SOct;
+	friend class AudioInputPDM;
 #endif
 protected:
 	AudioOutputI2S(int dummy): AudioStream(2, inputQueueArray) {} // to be used only inside AudioOutputI2Sslave !!

--- a/output_i2s.h
+++ b/output_i2s.h
@@ -41,6 +41,7 @@ public:
 	virtual void update(void);
 	void begin(void);
 	friend class AudioInputI2S;
+	friend class AudioInputPDM;
 #if defined(__IMXRT1062__)
 	friend class AudioOutputI2SQuad;
 	friend class AudioInputI2SQuad;
@@ -48,11 +49,10 @@ public:
 	friend class AudioInputI2SHex;
 	friend class AudioOutputI2SOct;
 	friend class AudioInputI2SOct;
-	friend class AudioInputPDM;
 #endif
 protected:
 	AudioOutputI2S(int dummy): AudioStream(2, inputQueueArray) {} // to be used only inside AudioOutputI2Sslave !!
-	static void config_i2s(void);
+	static void config_i2s(bool only_bclk = false);
 	static audio_block_t *block_left_1st;
 	static audio_block_t *block_right_1st;
 	static bool update_responsibility;


### PR DESCRIPTION
Needed the relevant setup (similar to input_i2s other than 32 bit word size, and no MCLK/LRCLK pins)
to allow this to function on the T4