### PR TITLE
Fix searchbar regular expression matching to be case-insensitive

### DIFF
--- a/gui/red/ui/palette.js
+++ b/gui/red/ui/palette.js
@@ -149,7 +149,7 @@ RED.palette = (function() {
 			$("#palette-search-clear").show();
 		}
 		
-		var re = new RegExp(val);
+		var re = new RegExp(val, "i");
 		$(".palette_node").each(function(i,el) {
 			if (val === "" || re.test(el.id)) {
 				$(this).show();


### PR DESCRIPTION
Add "i" option to RegExp parameters.  Since the matching is with class names which are mixed case it was behaviing counter-intuitively.