### PR TITLE
Fix for issue #403 AudioRecordQueue behaves incorrectly with no input

### DIFF
--- a/record_queue.cpp
+++ b/record_queue.cpp
@@ -43,14 +43,15 @@ void AudioRecordQueue::clear(void)
 {
 	uint32_t t;
 
-	if (userblock) {
+	if (NULL != userblock) {
 		release(userblock);
 		userblock = NULL;
 	}
 	t = tail;
 	while (t != head) {
 		if (++t >= max_buffers) t = 0;
-		release(queue[t]);
+		if (SILENT_BLOCK_FLAG != queue[t]) // real block?
+			release(queue[t]);
 	}
 	tail = t;
 }
@@ -59,12 +60,24 @@ int16_t * AudioRecordQueue::readBuffer(void)
 {
 	uint32_t t;
 
-	if (userblock) return NULL;
-	t = tail;
-	if (t == head) return NULL;
-	if (++t >= max_buffers) t = 0;
-	userblock = queue[t];
-	tail = t;
+	if (NULL == userblock) // no block passed to foreground yet
+	{
+		t = tail;
+		if (t == head) return NULL;
+		if (++t >= max_buffers) t = 0;
+		userblock = queue[t];
+		if (SILENT_BLOCK_FLAG == userblock) // got a NULL block, i.e. silence
+		{
+			userblock = allocate(); // allocate a block now, rather than one for every silent entry
+			if (NULL != userblock)	// if we got one...
+				memset(userblock->data,0,sizeof userblock->data); // ...set it to silent
+		}
+		tail = t;
+	}
+	// otherwise return data address previously sent, 
+	// rather than NULL, which according to the 
+	// documentation says no data available
+	
 	return userblock->data;
 }
 
@@ -81,16 +94,24 @@ void AudioRecordQueue::update(void)
 	uint32_t h;
 
 	block = receiveReadOnly();
-	if (!block) return;
+	//if (!block) return;
 	if (!enabled) {
-		release(block);
+		if (NULL != block)
+			release(block);
 		return;
 	}
+		
 	h = head + 1;
 	if (h >= max_buffers) h = 0;
-	if (h == tail) {
-		release(block);
+	if (h == tail) { // no room in queue
+		if (NULL != block)
+			release(block);
 	} else {
+		// No block supplied, but we are active: make a place-holder
+		if (NULL == block)
+			block = SILENT_BLOCK_FLAG;
+		
+		// queue the block or place-holder
 		queue[h] = block;
 		head = h;
 	}

--- a/record_queue.h
+++ b/record_queue.h
@@ -30,6 +30,8 @@
 #include "Arduino.h"
 #include "AudioStream.h"
 
+#define SILENT_BLOCK_FLAG ((audio_block_t*) 1)
+
 class AudioRecordQueue : public AudioStream
 {
 private:


### PR DESCRIPTION
record_queue.cpp - don't release() NULL or flag queue entries in ::clear(); allocate and blank a new audio block (if available) in ::readBuffer(), if we have a flag to say NULL (silence)  was received; also keep returning same block until it's discarded by calling ::freeBuffer(); put flag in queue if record is activated by ::begin() but receiving only NULL pointers

record_queue.h - define the "silent data" flag pointer