### PR TITLE
Fix PT8211 case no Audioblocks available

### DIFF
--- a/output_pt8211.cpp
+++ b/output_pt8211.cpp
@@ -342,12 +342,7 @@ void AudioOutputPT8211::isr(void)
 			offsetR += AUDIO_BLOCK_SAMPLES / 2;
 		#endif //defined(AUDIO_PT8211_OVERSAMPLING)
 	} else {
-		#if defined(AUDIO_PT8211_OVERSAMPLING)
-			memset(dest,0,AUDIO_BLOCK_SAMPLES*8);
-		#else
-			memset(dest,0,AUDIO_BLOCK_SAMPLES*2);
-		#endif
-		return;
+		memset(dest,0,sizeof(i2s_tx_buffer) / 2);
 	}
 
 	arm_dcache_flush_delete(dest_copy, sizeof(i2s_tx_buffer) / 2);


### PR DESCRIPTION
The memset in this case did not help - there was no cache handling because of the following return.  
Also simplified the lines a bit.  
That was a bug, and I hope the fix gets merged,