### PR TITLE
Fix for issue #415 (play queue stall)

### DIFF
--- a/examples/Queues/PlayQueueDemo/PlayQueueDemo.ino
+++ b/examples/Queues/PlayQueueDemo/PlayQueueDemo.ino
@@ -1,0 +1,174 @@
+/*
+ * A simple queue test which generates a sine wave in the 
+ * application and sends it to headphone jack. The results
+ * should always be a glitch-free wave, but various options
+ * can be changed to modify the usage of audio blocks, and an
+ * ability to execute the loop() function more slowly, with
+ * simple waveform generation, or more efficiently / faster,
+ * but requring some programmer effort to re-try if sending
+ * waveform data fails due to a lack of buffer or queue space.
+ *
+ * This example code is in the public domain.
+ * 
+ * Jonathan Oakley, November 2021
+ */
+ 
+ #include <Audio.h>
+#include <Wire.h>
+#include <SPI.h>
+#include <SD.h>
+#include <SerialFlash.h>
+
+// GUItool: begin automatically generated code
+AudioPlayQueue           queue1;         //xy=917,329
+AudioOutputI2S           i2s2;           //xy=1121,330
+AudioConnection          patchCord1(queue1, 0, i2s2, 0);
+AudioConnection          patchCord2(queue1, 0, i2s2, 1);
+AudioControlSGTL5000     sgtl5000_1;     //xy=1131,379
+// GUItool: end automatically generated code
+
+#define COUNT_OF(a) (sizeof a / sizeof a[0])
+
+uint32_t next;
+void setup() {
+  pinMode(13,OUTPUT);
+  
+  Serial.begin(115200);
+  while (!Serial)
+    ;
+
+  if (CrashReport) 
+  {
+    Serial.println(CrashReport);
+    CrashReport.clear();
+  }
+
+  AudioMemory(10);
+  
+  sgtl5000_1.enable();
+  sgtl5000_1.volume(0.5);
+
+  next = millis();
+  
+  // Comment the following out (or set to ORIGINAL) for old stall behaviour;
+  // set to NON_STALLING for return with status if audio blocks not available,
+  // or no room in queue for another audio block.
+  queue1.setBehaviour(AudioPlayQueue::NON_STALLING);
+
+  queue1.setMaxBuffers(4);
+}
+
+
+/*
+ * Generate one sample of a waveform.
+ * Currently 220Hz sine wave, but could make it more complex.
+ */
+uint32_t genLen;
+int16_t nextSample()
+{
+  static float phas = 0.f;
+  int16_t result = (int16_t) (sin(phas)*8000.);
+  genLen++;
+  
+  phas += 220./AUDIO_SAMPLE_RATE_EXACT*TWO_PI;
+  if (phas > TWO_PI)
+    phas -= TWO_PI;  
+
+  return result;
+}
+
+
+int loops;
+int nulls,nulls2;
+int testMode = 2; // 1: getBuffer / playBuffer; 2: play(), mix of samples and buffers
+int playMode; // 1: generate individual samples and send; 2: generate buffer of samples and send
+int16_t samples[512],*sptr; // space for samples when using play()
+uint32_t len; // number of buffered samples (remaining)
+
+void loop() {
+
+  switch (testMode)
+  {
+    case 1: // use getBuffer / playBuffer 
+    {  
+      int16_t* buf = queue1.getBuffer();
+      
+      if (NULL == buf)
+        nulls++;
+      else
+      {
+        for (int i=0;i<AUDIO_BLOCK_SAMPLES;i++)
+          buf[i] = nextSample();
+        queue1.playBuffer();
+      }
+    }
+      break;
+
+    case 2: // use play()
+    {
+      if (0 == len)
+      {
+        playMode = random(2)+1; // 1 or 2     
+      }
+        
+      switch (playMode)
+      {
+        case 1: // send single samples
+          if (0 == len)
+          {
+            len = random(10,2*AUDIO_BLOCK_SAMPLES+1); // be deliberately awkward
+            samples[0] = nextSample();
+          }
+          
+          while (len > 0)
+          {
+            if (0 == queue1.play(samples[0])) // sent a sample...
+            {
+              len--;        // count down
+              if (len > 0)  // if more to send...
+                samples[0] = nextSample(); // ...create the next one   
+            }
+            else
+            {
+              nulls++; // count up the re-tries
+              break;
+            }
+          }
+          break;
+        
+         case 2: // send a block of samples
+          if (0 == len)
+          {
+            len = random(10,COUNT_OF(samples)); // be deliberately awkward
+            for (int i=0;i<len;i++) // pre-fill the buffer
+              samples[i] = nextSample();
+            sptr = samples;
+          }
+          
+          {
+            uint32_t left = queue1.play(sptr,len); // send samples, maybe
+            if (left > 0) // not everything went
+            {
+              sptr += len - left; // advance the pointer
+              nulls2++; // count up the re-tries
+            }            
+            len = left; 
+          }
+          break;       
+      }
+    }
+      break;
+  }
+
+  loops++;
+  if (millis() > next)
+  {
+    next += 100; // aim to output every 100ms
+    
+    // In NON_STALLING mode this loops really fast, and the millis() value goes up by
+    // 100 on every output line. In ORIGINAL mode the loop is slow, and the internal
+    // stall results in slightly unpredictable timestamps.
+    Serial.printf("%d: millis = %d, loops = %d, nulls = %u, nulls2 = %u, samples = %u\n",
+                  playMode,millis(),loops,nulls,nulls2,genLen);
+  }
+}

--- a/gui/index.html
+++ b/gui/index.html
@@ -2848,34 +2848,60 @@ Returns the actual achieved attenuation of the anti-aliasing filter. If the inpu
 	</table>
 	<h3>Functions</h3>
 	<p class=func><span class=keyword>setMaxBuffers</span>(uint8);</p>
-	<p class=desc>Set the maximum buffer block count for the queue to limit its size - by default 32 blocks are used on Teensy3's
-	  and 80 on Teeny 4's - this allows the value to be reduced so that the queue cannot get too far ahead, nor use up lots of
+	<p class=desc>Set the maximum buffer block count for the queue to limit its size - by default 32 blocks are used on Teensy 3.x
+	  and 80 on Teensy 4.x - this allows the value to be reduced so that the queue cannot get too far ahead, nor use up lots of
 	  audio blocks you might want for other purposes.  The minimum number of buffer blocks is 2.
 	</p>
 	<p class=func><span class=keyword>play</span>(int16);</p>
 	<p class=desc>add a single sample to the queue - no need to use getBuffer() or playBuffer() as this
-	  method does the necessary handling.  Note this method may block waiting for a spare buffer if the queue is full
+	  method does the necessary handling.  
+	  		</p>	  
+	  <p class=desc>If the behaviour is set to ORIGINAL then this method may block waiting for a spare buffer if the queue is full.
+	  		</p>	  
+	  <p class=desc>If the behaviour is set to NON_STALLING then this method may return a non-zero value: 
+	  in this case the call must be re-tried, passing in the original sample value.
 	</p>
 	<p class=func><span class=keyword>play</span>(int16[], length);</p>
 	<p class=desc>add multiple samples to the queue - no need to use getBuffer() or playBuffer() as this
-	  method does the necessary handling.  Note this method may block waiting for a spare buffer if the queue is full.
-	  The length should be the number of samples in the array.
+	  method does the necessary handling.  
+	  The length should be the number of samples in the array, which need not be a multiple of AUDIO_BLOCK_SAMPLES.
+	  <p class=desc>If the behaviour is set to ORIGINAL then this method may block waiting for a spare buffer if the queue is full.
+		</p>	  
+	  <p class=desc>If the behaviour is set to NON_STALLING then this method will return the number of samples unused (due to unavailable
+	  audio blocks or queue space): if non-zero then the call must be re-tried, with an updated array pointer and length.
+		</p>
 	</p>
 	<p class=func><span class=keyword>getBuffer</span>();</p>
-	<p class=desc>Returns a pointer to an array of 128 int16.  This buffer
+	<p class=desc>Returns a pointer to an array of AUDIO_BLOCK_SAMPLES (usually 128) int16.  This buffer
 	  is within the audio library memory pool, providing the most efficient
 	  way to input data to the audio system.  The buffer is likely to be
-	  populated by previously used data, so the entire 128 words should be
-	  written before calling playBuffer().  Only a single buffer should be
-	  requested at a time.  This function may return NULL if no memory is
-	  available.	  
+	  populated by previously used data, so the entire AUDIO_BLOCK_SAMPLES samples should be
+	  written before calling playBuffer().  Only a single buffer is allocated at any one time: 
+	  repeated calls to getBuffer() without calling playBuffer() will yield the same address.
+	<p class=desc>
+	  If the behaviour is set to ORIGINAL then this function will wait (possibly forever) for memory to become available. 
+	  If set to NON_STALLING then function may return NULL if no memory is available.			
+		</p>
 	</p>
 	<p>You may find it easier to use the play() methods unless performance is crucial.
 	</p>
 	<p class=func><span class=keyword>playBuffer</span>();</p>
 	<p class=desc>Transmit the buffer previously obtained from getBuffer().  If you use the play() methods you should not use this.
 	</p>
+	<p class=desc>
+	  If the behaviour is set to ORIGINAL then this function will wait (up to 2.9ms) for a queue space to become available. 
+	  If set to NON_STALLING then function may return a non-zero value if no queue space is free: 
+	  in this case the call must be re-tried later, before any further call to getBuffer() is made.
+		</p>
+	<p class=func><span class=keyword>setBehaviour</span>(value);</p>
+	<p class=desc>Value should be AudioPlayQueue::ORIGINAL to preserve the original behaviour of getBuffer() and playBuffer(), 
+		which can both stall until audio blocks or queue entries become available, with consequences for system performance.
+		Setting the value to AudioPlayQueue::NON_STALLING results in all the above functions returning promptly, but possibly
+		with a status indicating failure or a need to re-try. See the PlayQueueDemo example.
+	</p>
 	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Queues &gt; PlayQueueDemo
+	</p>
 		<p><a href="http://community.arm.com/groups/embedded/blog/2014/05/23/led-video-panel-at-maker-faire-2014" target="_blank">4320 LED Video+Sound Project</a>
 		</p>
 	<!--

--- a/play_queue.cpp
+++ b/play_queue.cpp
@@ -37,6 +37,7 @@ void AudioPlayQueue::setMaxBuffers(uint8_t maxb)
   max_buffers = maxb ;
 }
 
+
 bool AudioPlayQueue::available(void)
 {
         if (userblock) return true;
@@ -45,59 +46,175 @@ bool AudioPlayQueue::available(void)
         return false;
 }
 
-int16_t * AudioPlayQueue::getBuffer(void)
+
+/**
+ * Get address of current data buffer, newly allocated if necessary.
+ * With behaviour == ORIGINAL this will stall (calling yield()) until an audio block
+ * becomes available - there's no real guarantee this will ever happen...
+ * With behaviour == NON_STALLING this will never stall, and will conform to the published
+ * API by returning NULL if no audio block is available.
+ * \return: NULL if buffer not available, else pointer to buffer of AUDIO_BLOCK_SAMPLES of int16_t
+ */
+int16_t* AudioPlayQueue::getBuffer(void)
 {
-	if (userblock) return userblock->data;
-	while (1) {
-		userblock = allocate();
-		if (userblock) return userblock->data;
-		yield();
+	if (NULL == userblock) // not got one: try to get one
+	{
+		switch (behaviour)
+		{
+			default:
+				while (1) 
+				{
+					userblock = allocate();
+					if (userblock)
+						break;
+					yield();
+				}
+				break;
+				
+			case NON_STALLING:
+				userblock = allocate();
+				break;
+		}
 	}
+	
+	return userblock == NULL
+					?NULL
+					:userblock->data;
 }
 
-void AudioPlayQueue::playBuffer(void)
+
+/**
+ * Queue userblock for later playback in update().
+ * If there's no user block in use then we presume success: this means it's 
+ * safe to keep calling playBuffer() regularly even if we've not been 
+ * creating audio to be played.
+ * \return 0 for success, 1 for re-try required
+ */
+uint32_t AudioPlayQueue::playBuffer(void)
 {
+	uint32_t result = 0;
 	uint32_t h;
 
-	if (!userblock) return;
-	h = head + 1;
-	if (h >= max_buffers) h = 0;
-	while (tail == h) ; // wait until space in the queue
-	queue[h] = userblock;
-	head = h;
-	userblock = NULL;
+	if (userblock) // only need to queue if we have a user block!
+	{
+		// Find place for next queue entry
+		h = head + 1;
+		if (h >= max_buffers) h = 0;
+		
+		// Wait for space, or return "please re-try", depending on behaviour
+		switch (behaviour)
+		{
+			default:
+				while (tail == h); // wait until space in the queue
+				break;
+				
+			case NON_STALLING: 
+				if (tail == h)	// if no space...
+					result = 1;	// ...return 1: user code must re-try later
+				break;
+		}
+		
+		if (0 == result)
+		{
+			queue[h] = userblock;	// block is queued for transmission
+			head = h;				// head has changed
+			userblock = NULL;		// block no longer available for filling
+		}
+	}
+	
+	return result;
 }
 
-void AudioPlayQueue::play(int16_t data)
+
+/**
+ * Put sample to buffer, and queue if buffer full.
+ * \return 0: success; 1: failed, data not stored, call again with same data
+ */
+uint32_t AudioPlayQueue::play(int16_t data)
 {
-  int16_t * buf = getBuffer() ;
-  buf [uptr++] = data ;
-  if (uptr >= AUDIO_BLOCK_SAMPLES)
-  {
-    playBuffer() ;
-    uptr = 0 ;
-  }
+	uint32_t result = 1;
+	int16_t* buf = getBuffer();
+	
+	do
+	{		
+		if (NULL == buf) // no buffer, failed already
+			break;
+
+		if (uptr >= AUDIO_BLOCK_SAMPLES) // buffer is full, we're re-called: try again
+		{
+			if (0 == playBuffer()) // success emitting old buffer...
+			{
+				uptr = 0;			// ...start at beginning...
+				buf = getBuffer();	// ...of new buffer
+				continue;			// loop to check buffer and store the sample
+			}
+		}
+		else // non-full buffer
+		{
+		  buf [uptr++] = data ;
+		  result = 0;
+		  if (uptr >= AUDIO_BLOCK_SAMPLES	// buffer is full...
+		   && 0 == playBuffer())			// ... try to queue it
+			  uptr = 0; // success!
+		}
+	} while (false);
+	
+	return result;
 }
 
-void AudioPlayQueue::play(const int16_t *data, uint32_t len)
+/**
+ * Put multiple samples to buffer(s), and queue if buffer(s) full.
+ * \return 0: success; >0: failed, data not stored, call again with remaining data (return is unused data length)
+ */
+uint32_t AudioPlayQueue::play(const int16_t *data, uint32_t len)
 {
-  while (len > 0)
-  {
-    unsigned int avail_in_userblock = AUDIO_BLOCK_SAMPLES - uptr ;
-    unsigned int to_copy = avail_in_userblock > len ? len : avail_in_userblock ;
-    int16_t * buf = getBuffer();
-    memcpy ((void*)(buf+uptr), (void*)data, to_copy * sizeof(int16_t)) ;
-    uptr += to_copy ;
+	uint32_t result = len;
+	int16_t * buf = getBuffer();
+	
+	do
+	{
+		unsigned int avail_in_userblock = AUDIO_BLOCK_SAMPLES - uptr ;
+		unsigned int to_copy = avail_in_userblock > len ? len : avail_in_userblock ;
+		
+		if (NULL == buf) // no buffer, failed
+			break; 
+			
+		if (uptr >= AUDIO_BLOCK_SAMPLES) // buffer is full, we're re-called: try again
+		{
+			if (0 == playBuffer()) // success emitting old buffer...
+			{
+				uptr = 0;			// ...start at beginning...
+				buf = getBuffer();	// ...of new buffer
+				continue;			// loop to check buffer and store more samples
+			}
+		}
+		
+		if (0 == len) // nothing left to do
+			break;
+			
+		// we have a buffer and something to copy to it: do that
+		memcpy ((void*)(buf+uptr), (void*)data, to_copy * sizeof(int16_t)) ;
+		uptr   += to_copy;
+		data   += to_copy;
+		len    -= to_copy;
+		result -= to_copy;
+		
+		if (uptr >= AUDIO_BLOCK_SAMPLES)	// buffer is full...
+		{
+			if (0 == playBuffer())			// ... try to queue it
+			{
+				uptr = 0;					// success!
+				if (len > 0)				// more to buffer...
+					buf = getBuffer();		// ...try to do that
+			}
+			else
+				break;	// queue failed: exit and try again later
+		}
+	} while (len > 0);
 
-    data += to_copy ;
-    len -= to_copy ;
-    if (uptr >= AUDIO_BLOCK_SAMPLES)
-    {
-      playBuffer() ;
-      uptr = 0 ;
-    }
-  }
+	return result;
 }
+
 
 void AudioPlayQueue::update(void)
 {
@@ -110,7 +227,8 @@ void AudioPlayQueue::update(void)
 		block = queue[t];
 		tail = t;
 		transmit(block);
-		release(block);
+		release(block);	 // we've lost interest in this block...
+		queue[t] = NULL; // ...forget it here, too
 	}
 }
 

--- a/play_queue.h
+++ b/play_queue.h
@@ -41,21 +41,24 @@ private:
 public:
 	AudioPlayQueue(void) : AudioStream(0, NULL),
 	  userblock(NULL), uptr(0), head(0), tail(0), max_buffers(MAX_BUFFERS) { }
-	void play(int16_t data);
-	void play(const int16_t *data, uint32_t len);
+	uint32_t play(int16_t data);
+	uint32_t play(const int16_t *data, uint32_t len);
 	bool available(void);
 	int16_t * getBuffer(void);
-	void playBuffer(void);
+	uint32_t playBuffer(void);
 	void stop(void);
 	void setMaxBuffers(uint8_t);
 	//bool isPlaying(void) { return playing; }
 	virtual void update(void);
+	enum behaviour_e {ORIGINAL,NON_STALLING};
+	void setBehaviour(behaviour_e behave) {behaviour = behave;}
 private:
 	audio_block_t *queue[MAX_BUFFERS];
 	audio_block_t *userblock;
-	unsigned int uptr;
+	unsigned int uptr; // actually an index, NOT a pointer!
 	volatile uint8_t head, tail;
-	volatile unsigned int max_buffers;
+	volatile uint8_t max_buffers;
+	behaviour_e behaviour;
 };
 
 #endif


### PR DESCRIPTION
Fixes issue #415 by optionally providing error returns from various methods, instead of burning CPU waiting for audio blocks or queue space to free up. Defaults to original behaviour so old code should still work the same. Updated GUI documentation is included.

Adds an example which demonstrates the various modes of operation.