### PR TITLE
Update to play_sd_wav/raw with method to use different FS

### DIFF
--- a/play_sd_raw.cpp
+++ b/play_sd_raw.cpp
@@ -64,6 +64,33 @@ bool AudioPlaySdRaw::play(const char *filename)
 	return true;
 }
 
+bool AudioPlaySdRaw::play(FS *fs, const char *filename)
+{
+	stop();
+#if defined(HAS_KINETIS_SDHC)
+	if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStartUsingSPI();
+#else
+	AudioStartUsingSPI();
+#endif
+	__disable_irq();
+	rawfile = fs->open(filename);
+	__enable_irq();
+	if (!rawfile) {
+		//Serial.println("unable to open file");
+		#if defined(HAS_KINETIS_SDHC)
+			if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
+		#else
+			AudioStopUsingSPI();
+		#endif
+		return false;
+	}
+	file_size = rawfile.size();
+	file_offset = 0;
+	//Serial.println("able to open file");
+	playing = true;
+	return true;
+}
+
 void AudioPlaySdRaw::stop(void)
 {
 	__disable_irq();

--- a/play_sd_raw.h
+++ b/play_sd_raw.h
@@ -37,6 +37,7 @@ public:
 	AudioPlaySdRaw(void) : AudioStream(0, NULL) { begin(); }
 	void begin(void);
 	bool play(const char *filename);
+	bool play(FS *fs, const char *filename);
 	void stop(void);
 	bool isPlaying(void) { return playing; }
 	uint32_t positionMillis(void);

--- a/play_sd_wav.h
+++ b/play_sd_wav.h
@@ -37,6 +37,7 @@ public:
 	AudioPlaySdWav(void) : AudioStream(0, NULL), block_left(NULL), block_right(NULL) { begin(); }
 	void begin(void);
 	bool play(const char *filename);
+	bool play(FS *fs, const char *filename);
 	void togglePlayPause(void);
 	void stop(void);
 	bool isPlaying(void);


### PR DESCRIPTION
While playing with MTP/FS Audio we modified the play_sd_wav and play_sd_raw with an addition method based on what @wwatson did for Franks Codec library: https://forum.pjrc.com/threads/68816-Now-for-MP3-with-FS to use different FS as well.  So after a bunch of debugging by @KurtE and @Frank B we now have all of Frank's codec library working with the T4.1 (+audio shield).  With this change we are now able to play wav files on FS device - tested with memboard chips, QSPI, SD Cards and USB.  All seem to be working well.

Basically just added a second play method:
`bool AudioPlaySdWav::play(FS *fs, const char *filename)`
and change using SD.open to
`wavfile = fs->open(filename);`

nothing else changed.

Don't have any midi equipment or fancy audio stuff to test so fair warning.