### PR TITLE
memcpy_tointerleave allow AUDIO_BLOCK_SAMPLES == 4

### DIFF
--- a/memcpy_audio.S
+++ b/memcpy_audio.S
@@ -85,7 +85,18 @@
 	pkhtb r6,r8,r7,ASR #16
 
 	stmia r0!, {r3,r4,r5,r6}
-	pop	{r4-r8,r14}	
+	pop	{r4-r8,r14}
+#elif AUDIO_BLOCK_SAMPLES == 4
+	push	{r4-r6,r14}
+
+	ldmia r1!, {r5}
+	ldmia r2!, {r6}
+
+	pkhbt r3,r5,r6,LSL #16
+	pkhtb r4,r6,r5,ASR #16
+
+	stmia r0!, {r3,r4}
+	pop	{r4-r6,r14}
 #endif
 	BX lr
 	
@@ -146,7 +157,7 @@
 	BX lr
 
 	
-/* void memcpy_tointerleaveL(short *dst, short *srcR); */
+/* void memcpy_tointerleaveR(short *dst, short *srcR); */
  .global	memcpy_tointerleaveR
 .thumb_func
 	memcpy_tointerleaveR:


### PR DESCRIPTION
Previous code won't work for AUDIO_BLOCK_SAMPLES < 8.  So I would like to add a case for AUDIO_BLOCK_SAMPLES == 4, using the same pattern of interleaving code as for AUDIO_BLOCK_SAMPLES == 8, but just half as much.

I've tested on my Teensy 4.1 with Audio Board Rev D with L/R audio.  I haven't looked into the other two functions memcpy_tointerleaveL and memcpy_tointerleaveR but I assume a similar additional case could be done for that.