### PR TITLE
allow compile AUDIO_BLOCK_SAMPLES = 4 or 8

### DIFF
--- a/effect_freeverb.cpp
+++ b/effect_freeverb.cpp
@@ -97,7 +97,13 @@ static int16_t sat16(int32_t n, int rshift) {
 // TODO: move this to one of the data files, use in output_adat.cpp, output_tdm.cpp, etc
 static const audio_block_t zeroblock = {
 0, 0, 0, {
-0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0,
+#if AUDIO_BLOCK_SAMPLES > 4
+0, 0, 0, 0,
+#endif
+#if AUDIO_BLOCK_SAMPLES > 8
+0, 0, 0, 0, 0, 0, 0, 0,
+#endif
 #if AUDIO_BLOCK_SAMPLES > 16
 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 #endif


### PR DESCRIPTION
I'm just trying to get the audio library to compile when AUDIO_BLOCK_SAMPLES == 4 or AUDIO_BLOCK_SAMPLES == 8, which would produce the compile error:

```
/home/e/arduino-1.8.16/hardware/teensy/avr/libraries/Audio/effect_freeverb.cpp:122:3: error: too many initializers for 'int16_t [8] {aka short int [8]}'
 } };
   ^
Multiple libraries were found for "SD.h"
 Used: /home/e/arduino-1.8.16/hardware/teensy/avr/libraries/SD
 Not used: /home/e/arduino-1.8.16/libraries/SD
Error compiling for board Teensy 4.1.
```

I haven't looked closely at this effect, but it seems if the effect just wants a zero block then this would suffice.  However, if for what ever reason this effect isn't supposed to work for (AUDIO_BLOCK_SAMPLES < 16), then maybe could just disable this .cpp and .h file.