### PR TITLE
input_tdm: every odd channel had every other sample swapped

### DIFF
--- a/input_tdm.cpp
+++ b/input_tdm.cpp
@@ -98,8 +98,8 @@ static void memcpy_tdm_rx(uint32_t *dest1, uint32_t *dest2, const uint32_t *src)
 		in1 = *src;
 		in2 = *(src+8);
 		src += 16;
-		*dest1++ = (in1 >> 16) | (in2 & 0xFFFF0000);
-		*dest2++ = (in1 << 16) | (in2 & 0x0000FFFF);
+		*dest1++ = ((in1 >> 16) & 0x0000FFFF) | ((in2 <<  0) & 0xFFFF0000);
+		*dest2++ = ((in1 >>  0) & 0x0000FFFF) | ((in2 << 16) & 0xFFFF0000);
 	}
 }
 

--- a/input_tdm2.cpp
+++ b/input_tdm2.cpp
@@ -79,8 +79,8 @@ static void memcpy_tdm_rx(uint32_t *dest1, uint32_t *dest2, const uint32_t *src)
 		in1 = *src;
 		in2 = *(src+8);
 		src += 16;
-		*dest1++ = (in1 >> 16) | (in2 & 0xFFFF0000);
-		*dest2++ = (in1 << 16) | (in2 & 0x0000FFFF);
+		*dest1++ = ((in1 >> 16) & 0x0000FFFF) | ((in2 <<  0) & 0xFFFF0000);
+		*dest2++ = ((in1 >>  0) & 0x0000FFFF) | ((in2 << 16) & 0xFFFF0000);
 	}
 }
 


### PR DESCRIPTION
In every odd channel in TDM input (1, 3, 5, 7, 9, 11, 13, 15), every other word was swapped due to an incorrect copy from 32-bits to 16-bits.  

This fix corrects the odd channels.   The Shift-by zeros 
 and the extraneous logical ands are there for clarity, and I verified they don't end up affecting final code optimization as long as optimization is turned on.