### PR TITLE
Compiler warnings in output_pwm.cpp

### DIFF
--- a/output_pt8211.cpp
+++ b/output_pt8211.cpp
@@ -99,14 +99,14 @@ void AudioOutputPT8211::begin(void)
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_tx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 	dma.TCD->DADDR = (void *)((uint32_t)&I2S1_TDR0);
+	dma.attachInterrupt(isr);
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_TX);
+	dma.enable();
 
 	I2S1_RCSR |= I2S_RCSR_RE;
 	I2S1_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
 
 	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
-	dma.enable();
 	return;
 #endif
 }

--- a/output_pt8211_2.cpp
+++ b/output_pt8211_2.cpp
@@ -72,12 +72,12 @@ void AudioOutputPT8211_2::begin(void)
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 	dma.TCD->DADDR = (void *)((uint32_t)&I2S2_TDR0);
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_TX);
+	dma.attachInterrupt(isr);
+	dma.enable();
 
 	I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
 
 	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
-	dma.enable();
 }
 
 void AudioOutputPT8211_2::isr(void)

--- a/output_pwm.cpp
+++ b/output_pwm.cpp
@@ -367,7 +367,7 @@ void AudioOutputPWM::isr(void)
 		arm_dcache_flush_delete(dest, sizeof(pwm_tx_buffer[0]) / 2 );
 		arm_dcache_flush_delete(dest1, sizeof(pwm_tx_buffer[1]) / 2 );
 		
-		AudioStream::release(block);
+		AudioStream::release((audio_block_t *)block);  // block is defined as volatile
 		block = NULL;
 	} else {
 		//Serial.println(".");
@@ -399,7 +399,7 @@ void AudioOutputPWM::update(void)
 	audio_block_t * new_block = receiveReadOnly();
 	audio_block_t * old_block ;
 	__disable_irq();
-	old_block = block ;
+	old_block = (audio_block_t*)block ;  // block is defined as volatile
 	block = new_block ;
 	__enable_irq();
 	if (old_block)


### PR DESCRIPTION
Paul, not a big deal but when building and debugging I try to remove all of the warnings if possible


There are two warnings in output_pwm.cpp that were caused by the class
defining the member variable block as volatile,

but passed when it was going to release the block, it complained that you are passing it to a non-volatile...

So cast the pointer as to remove the warning.

Sorry sort of combined the warnings fix with maybe fix for PTS8211
