### PR TITLE
Actually use arm_dcache_flush() in AudioOutputSPDIF3

### DIFF
--- a/output_spdif3.cpp
+++ b/output_spdif3.cpp
@@ -144,7 +144,7 @@ void AudioOutputSPDIF3::isr(void)
 		// Experience suggests it works better to flush 
 		// after the copy, rather than before...
 		#if IMXRT_CACHE_ENABLED >= 2
-		arm_dcache_flush_delete(dest-8,8 * sizeof *dest);
+		arm_dcache_flush(dest-8,8 * sizeof *dest);
 		#endif
 	} while (dest < end);
 


### PR DESCRIPTION
...as requested, rather than the arm_dcache_flush_delete() which was what the original code effectively had in it. Still seems to work OK, and is faster, too.