### PR TITLE
Fix/io inits

### DIFF
--- a/async_input_spdif3.cpp
+++ b/async_input_spdif3.cpp
@@ -96,14 +96,16 @@ void AsyncAudioInputSPDIF3::begin()
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;	
 	dma.TCD->SADDR = (void *)((uint32_t)&SPDIF_SRL);
 	dma.TCD->DADDR = spdif_rx_buffer;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SPDIF_RX);
 
-	//SPDIF_SCR |=SPDIF_SCR_DMA_RX_EN;		//DMA Receive Request Enable
-	dma.enable();
 	dma.attachInterrupt(isr);
+	dma.enable();
+
 #ifdef DEBUG_SPDIF_IN
 	while (!Serial);
 #endif
+
 	_bufferLPFilter.pCoeffs=new float[5];
 	_bufferLPFilter.numStages=1;
 	_bufferLPFilter.pState=new float[2];

--- a/input_adcs.cpp
+++ b/input_adcs.cpp
@@ -80,26 +80,6 @@ void AudioInputAnalogStereo::init(uint8_t pin0, uint8_t pin1)
     hpf_x1[1] = tmp;   // With constant DC level x1 would be x0
     hpf_y1[1] = 0;     // Output will settle here when stable
 
-
-	// set the programmable delay block to trigger the ADC at 44.1 kHz
-	//if (!(SIM_SCGC6 & SIM_SCGC6_PDB)
-	  //|| (PDB0_SC & PDB_CONFIG) != PDB_CONFIG
-	  //|| PDB0_MOD != PDB_PERIOD
-	  //|| PDB0_IDLY != 1
-	  //|| PDB0_CH0C1 != 0x0101) {
-		SIM_SCGC6 |= SIM_SCGC6_PDB;
-		PDB0_IDLY = 1;
-		PDB0_MOD = PDB_PERIOD;
-		PDB0_SC = PDB_CONFIG | PDB_SC_LDOK;
-		PDB0_SC = PDB_CONFIG | PDB_SC_SWTRIG;
-		PDB0_CH0C1 = 0x0101;
-		PDB0_CH1C1 = 0x0101;
-	//}
-
-	// enable the ADC for hardware trigger and DMA
-	ADC0_SC2 |= ADC_SC2_ADTRG | ADC_SC2_DMAEN;
-	ADC1_SC2 |= ADC_SC2_ADTRG | ADC_SC2_DMAEN;
-
 	// set up a DMA channel to store the ADC data
 	dma0.begin(true);
 	dma1.begin(true);
@@ -133,11 +113,32 @@ void AudioInputAnalogStereo::init(uint8_t pin0, uint8_t pin1)
 	//dma1.triggerAtHardwareEvent(DMAMUX_SOURCE_ADC1);
 	dma1.triggerAtTransfersOf(dma0);
 	dma1.triggerAtCompletionOf(dma0);
+	
 	update_responsibility = update_setup();
-	dma0.enable();
-	dma1.enable();
 	dma0.attachInterrupt(isr0);
 	dma1.attachInterrupt(isr1);
+	dma0.enable();
+	dma1.enable();
+	
+	// set the programmable delay block to trigger the ADC at 44.1 kHz
+	//if (!(SIM_SCGC6 & SIM_SCGC6_PDB)
+	  //|| (PDB0_SC & PDB_CONFIG) != PDB_CONFIG
+	  //|| PDB0_MOD != PDB_PERIOD
+	  //|| PDB0_IDLY != 1
+	  //|| PDB0_CH0C1 != 0x0101) {
+		SIM_SCGC6 |= SIM_SCGC6_PDB;
+		PDB0_IDLY = 1;
+		PDB0_MOD = PDB_PERIOD;
+		PDB0_SC = PDB_CONFIG | PDB_SC_LDOK;
+		PDB0_SC = PDB_CONFIG | PDB_SC_SWTRIG;
+		PDB0_CH0C1 = 0x0101;
+		PDB0_CH1C1 = 0x0101;
+	//}
+
+	// enable the ADC for hardware trigger and DMA
+	ADC0_SC2 |= ADC_SC2_ADTRG | ADC_SC2_DMAEN;
+	ADC1_SC2 |= ADC_SC2_ADTRG | ADC_SC2_DMAEN;
+
 }
 
 

--- a/input_i2s.cpp
+++ b/input_i2s.cpp
@@ -61,8 +61,13 @@ void AudioInputI2S::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(i2s_rx_buffer);
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_rx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_RX);
 
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
+	dma.enable();
+	
 	I2S0_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
 
@@ -81,13 +86,15 @@ void AudioInputI2S::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(i2s_rx_buffer);
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_rx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
 
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
+	dma.enable();
+	
 	I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 #endif
-	update_responsibility = update_setup();
-	dma.enable();
-	dma.attachInterrupt(isr);
 }
 
 void AudioInputI2S::isr(void)
@@ -211,12 +218,13 @@ void AudioInputI2Sslave::begin(void)
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_RX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S0_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
-	dma.attachInterrupt(isr);
 
 #elif defined(__IMXRT1062__)
 	CORE_PIN8_CONFIG  = 3;  //1:RX_DATA0
@@ -233,13 +241,15 @@ void AudioInputI2Sslave::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(i2s_rx_buffer);
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_rx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S1_RCSR = 0;
 	I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
-	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
 #endif
 }
 
@@ -273,7 +283,9 @@ void AudioInputI2S::begin(void)
 	dma1.CFG->SAR = (void *)((uint32_t)&I2S0_RDR0 + 2);
 	dma1.CFG->DCR = (dma1.CFG->DCR & 0xF08E0FFF) | DMA_DCR_SSIZE(2);
 	dma1.destinationBuffer(i2s_rx_buffer1, sizeof(i2s_rx_buffer1));
+	
 	dma1.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_RX);
+	
 	dma1.interruptAtCompletion();
 	dma1.disableOnCompletion();
 	dma1.attachInterrupt(isr1);
@@ -283,14 +295,14 @@ void AudioInputI2S::begin(void)
 	dma2.destinationBuffer(i2s_rx_buffer2, sizeof(i2s_rx_buffer2));
 	dma2.interruptAtCompletion();
 	dma2.disableOnCompletion();
-	dma2.attachInterrupt(isr2);
+	
+	update_responsibility = update_setup();
+	dma2.attachInterrupt(isr2); // isr2 triggers update_all()
+	dma1.enable();
 
 	I2S0_RCSR = 0;
 	I2S0_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FWDE | I2S_RCSR_FR;
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
-
-	update_responsibility = update_setup();
-	dma1.enable();
 }
 
 void AudioInputI2S::update(void)

--- a/input_i2s2.cpp
+++ b/input_i2s2.cpp
@@ -62,14 +62,15 @@ void AudioInputI2S2::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(i2s2_rx_buffer);
 	dma.TCD->BITER_ELINKNO = sizeof(i2s2_rx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_RX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S2_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR; // page 2099
 	I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // page 2087
-
-	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
 }
 
 void AudioInputI2S2::isr(void)
@@ -195,14 +196,14 @@ void AudioInputI2S2slave::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(i2s2_rx_buffer);
 	dma.TCD->BITER_ELINKNO = sizeof(i2s2_rx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
-	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_RX);
-	dma.enable();
 	
+	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_RX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
+	dma.enable();	
 	
 	I2S2_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR; // page 2099
 	I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // page 2087
-	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
-
 }
 #endif

--- a/input_i2s_hex.cpp
+++ b/input_i2s_hex.cpp
@@ -79,14 +79,16 @@ void AudioInputI2SHex::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(i2s_rx_buffer);
 	dma.TCD->BITER_ELINKNO = AUDIO_BLOCK_SAMPLES * 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
 
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
+	dma.enable();
+	
 	//I2S1_RCSR = 0;
 	//I2S1_RCR3 = I2S_RCR3_RCE_2CH << pinoffset;
 	I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
-	update_responsibility = update_setup();
-	dma.enable();
-	dma.attachInterrupt(isr);
 }
 
 void AudioInputI2SHex::isr(void)

--- a/input_i2s_oct.cpp
+++ b/input_i2s_oct.cpp
@@ -71,12 +71,14 @@ void AudioInputI2SOct::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(i2s_rx_buffer);
 	dma.TCD->BITER_ELINKNO = AUDIO_BLOCK_SAMPLES * 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
 
-	I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 	update_responsibility = update_setup();
-	dma.enable();
 	dma.attachInterrupt(isr);
+	dma.enable();
+	
+	I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 }
 
 void AudioInputI2SOct::isr(void)

--- a/input_i2s_quad.cpp
+++ b/input_i2s_quad.cpp
@@ -69,12 +69,13 @@ void AudioInputI2SQuad::begin(void)
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 #endif
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_RX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S0_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
-	dma.attachInterrupt(isr);
 
 #elif defined(__IMXRT1062__)
 	const int pinoffset = 0; // TODO: make this configurable...
@@ -113,15 +114,16 @@ void AudioInputI2SQuad::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(i2s_rx_buffer);
 	dma.TCD->BITER_ELINKNO = AUDIO_BLOCK_SAMPLES * 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
 
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
+	dma.enable();
+	
 	I2S1_RCSR = 0;
 	I2S1_RCR3 = I2S_RCR3_RCE_2CH << pinoffset;
-
 	I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
-	update_responsibility = update_setup();
-	dma.enable();
-	dma.attachInterrupt(isr);
 #endif
 }
 

--- a/input_pdm.cpp
+++ b/input_pdm.cpp
@@ -139,13 +139,12 @@ void AudioInputPDM::begin()
   dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
   
   update_responsibility = update_setup();
+  dma.attachInterrupt(isr);
   dma.enable();
 
   I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
   //I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
   //I2S1_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
-
-  dma.attachInterrupt(isr);
 }
 
 
@@ -261,12 +260,13 @@ void AudioInputPDM::begin(void)
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_RX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S0_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
-	dma.attachInterrupt(isr);
 }
 #endif
 

--- a/input_pdm_i2s2.cpp
+++ b/input_pdm_i2s2.cpp
@@ -131,12 +131,12 @@ void AudioInputPDM2::begin(void)
   dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 
   dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_RX);
+  
   update_responsibility = update_setup();
+  dma.attachInterrupt(isr);
   dma.enable();
 
   I2S2_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
-
-  dma.attachInterrupt(isr);
 }
 
 extern const int16_t enormous_pdm_filter_table[];

--- a/input_spdif3.cpp
+++ b/input_spdif3.cpp
@@ -63,6 +63,7 @@ void AudioInputSPDIF3::begin(void)
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SPDIF_RX);
+	
 	update_responsibility = update_setup();
 	dma.attachInterrupt(isr);
 	dma.enable();

--- a/input_tdm.cpp
+++ b/input_tdm.cpp
@@ -59,13 +59,15 @@ void AudioInputTDM::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(tdm_rx_buffer);
 	dma.TCD->BITER_ELINKNO = sizeof(tdm_rx_buffer) / 4;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_RX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S0_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
-	dma.attachInterrupt(isr);
 #elif defined(__IMXRT1062__)
 	CORE_PIN8_CONFIG  = 3;  //RX_DATA0
 	IOMUXC_SAI1_RX_DATA0_SELECT_INPUT = 2;
@@ -80,12 +82,14 @@ void AudioInputTDM::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(tdm_rx_buffer);
 	dma.TCD->BITER_ELINKNO = sizeof(tdm_rx_buffer) / 4;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);	
 	dma.enable();
 
 	I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
-	dma.attachInterrupt(isr);	
 #endif	
 }
 

--- a/input_tdm2.cpp
+++ b/input_tdm2.cpp
@@ -60,14 +60,15 @@ void AudioInputTDM2::begin(void)
 	dma.TCD->DLASTSGA = -sizeof(tdm_rx_buffer);
 	dma.TCD->BITER_ELINKNO = sizeof(tdm_rx_buffer) / 4;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_RX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);	
 	dma.enable();
 
 	I2S2_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 	I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE;
-	dma.attachInterrupt(isr);	
-
 }
 
 // TODO: needs optimization...

--- a/output_adat.cpp
+++ b/output_adat.cpp
@@ -98,13 +98,14 @@ void AudioOutputADAT::begin(void)
 	dma.TCD->DLASTSGA = 0;
 	dma.TCD->BITER_ELINKNO = sizeof(ADAT_tx_buffer) / nbytes_mlno;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_TX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE | I2S_TCSR_FR;
-	dma.attachInterrupt(isr);
-
 }
 
 /*

--- a/output_i2s.cpp
+++ b/output_i2s.cpp
@@ -73,7 +73,11 @@ void AudioOutputI2S::begin(void)
 	dma.TCD->DLASTSGA = 0;
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_tx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_TX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S0_TCSR = I2S_TCSR_SR;
@@ -92,14 +96,16 @@ void AudioOutputI2S::begin(void)
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_tx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 	dma.TCD->DADDR = (void *)((uint32_t)&I2S1_TDR0 + 2);
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_TX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE;
 	I2S1_TCSR = I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
 #endif
-	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
 }
 
 
@@ -486,7 +492,11 @@ void AudioOutputI2Sslave::begin(void)
 	dma.TCD->DLASTSGA = 0;
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_tx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_TX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S0_TCSR = I2S_TCSR_SR;
@@ -505,15 +515,17 @@ void AudioOutputI2Sslave::begin(void)
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_tx_buffer) / 2;
 	dma.TCD->DADDR = (void *)((uint32_t)&I2S1_TDR0 + 2);
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_TX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE;
 	I2S1_TCSR = I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
 #endif
 
-	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
 }
 
 void AudioOutputI2Sslave::config_i2s(void)
@@ -631,20 +643,21 @@ void AudioOutputI2S::begin(void)
 	dma1.sourceBuffer(i2s_tx_buffer1, sizeof(i2s_tx_buffer1));
 	dma1.CFG->DAR = (void *)((uint32_t)&I2S0_TDR0);
 	dma1.CFG->DCR = (dma1.CFG->DCR & 0xF0F0F0FF) | DMA_DCR_DSIZE(2);
+	
 	dma1.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_TX);
+	
 	dma1.interruptAtCompletion();
 	dma1.disableOnCompletion();
 	dma1.attachInterrupt(isr1);
-
 
 	dma2.sourceBuffer(i2s_tx_buffer2, sizeof(i2s_tx_buffer2));
 	dma2.CFG->DAR = dma1.CFG->DAR;
 	dma2.CFG->DCR = dma1.CFG->DCR;
 	dma2.interruptAtCompletion();
 	dma2.disableOnCompletion();
+	
+	update_responsibility = update_setup(); // isr2 is the one which calls update_all()
 	dma2.attachInterrupt(isr2);
-
-	update_responsibility = update_setup();
 	dma1.enable();
 
 	I2S0_TCSR = I2S_TCSR_SR;
@@ -789,7 +802,9 @@ void AudioOutputI2Sslave::begin(void)
 	dma1.sourceBuffer(i2s_tx_buffer1, sizeof(i2s_tx_buffer1));
 	dma1.CFG->DAR = (void *)((uint32_t)&I2S0_TDR0 + 2);
 	dma1.CFG->DCR = (dma1.CFG->DCR & 0xF0F0F0FF) | DMA_DCR_DSIZE(2);
+	
 	dma1.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_TX);
+	
 	dma1.interruptAtCompletion();
 	dma1.disableOnCompletion();
 	dma1.attachInterrupt(isr1);
@@ -799,9 +814,9 @@ void AudioOutputI2Sslave::begin(void)
 	dma2.CFG->DCR = dma1.CFG->DCR;
 	dma2.interruptAtCompletion();
 	dma2.disableOnCompletion();
+	
+	update_responsibility = update_setup(); // isr2 is the one which calls update_all()
 	dma2.attachInterrupt(isr2);
-
-	update_responsibility = update_setup();
 	dma1.enable();
 
 	I2S0_TCSR = I2S_TCSR_SR;

--- a/output_i2s2.cpp
+++ b/output_i2s2.cpp
@@ -67,13 +67,14 @@ void AudioOutputI2S2::begin(void)
 	dma.TCD->BITER_ELINKNO = sizeof(i2s2_tx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 	dma.TCD->DADDR = (void *)((uint32_t)&I2S2_TDR0 + 2);
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_TX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE | I2S_TCSR_FR;
-
-	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
 }
 
 void AudioOutputI2S2::isr(void)
@@ -269,14 +270,14 @@ void AudioOutputI2S2slave::begin(void)
 	dma.TCD->BITER_ELINKNO = sizeof(i2s2_tx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 	dma.TCD->DADDR = (void *)((uint32_t)&I2S2_TDR0 + 2);
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_TX);
-	dma.enable();
-
-	I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE | I2S_TCSR_FR;
 
 	update_responsibility = update_setup();
 	dma.attachInterrupt(isr);
+	dma.enable();
 
+	I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE | I2S_TCSR_FR;
 }
 
 void AudioOutputI2S2slave::config_i2s(void)

--- a/output_i2s_hex.cpp
+++ b/output_i2s_hex.cpp
@@ -95,13 +95,16 @@ void AudioOutputI2SHex::begin(void)
 	dma.TCD->DLASTSGA = -12;
 	dma.TCD->BITER_ELINKNO = AUDIO_BLOCK_SAMPLES * 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_TX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
+	
 	I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE;
 	I2S1_TCSR = I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
 	I2S1_TCR3 = I2S_TCR3_TCE_3CH << pinoffset;
-	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
 }
 
 void AudioOutputI2SHex::isr(void)

--- a/output_i2s_oct.cpp
+++ b/output_i2s_oct.cpp
@@ -93,13 +93,16 @@ void AudioOutputI2SOct::begin(void)
 	dma.TCD->DLASTSGA = -16;
 	dma.TCD->BITER_ELINKNO = AUDIO_BLOCK_SAMPLES * 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_TX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
+	
 	I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE;
 	I2S1_TCSR = I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
 	//I2S1_TCR3 = I2S_TCR3_TCE_4CH;
-	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
 }
 
 void AudioOutputI2SOct::isr(void)

--- a/output_i2s_quad.cpp
+++ b/output_i2s_quad.cpp
@@ -79,14 +79,15 @@ void AudioOutputI2SQuad::begin(void)
 	dma.TCD->DLASTSGA = 0;
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_tx_buffer) / 4;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_TX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S0_TCSR = I2S_TCSR_SR;
 	I2S0_TCSR = I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
-	dma.attachInterrupt(isr);
-
 #elif defined(__IMXRT1062__)
 	const int pinoffset = 0; // TODO: make this configurable...
 	memset(i2s_tx_buffer, 0, sizeof(i2s_tx_buffer));
@@ -118,13 +119,16 @@ void AudioOutputI2SQuad::begin(void)
 	dma.TCD->DLASTSGA = -8;
 	dma.TCD->BITER_ELINKNO = AUDIO_BLOCK_SAMPLES * 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_TX);
+	
+	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
+	
 	I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE;
 	I2S1_TCSR = I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
 	I2S1_TCR3 = I2S_TCR3_TCE_2CH << pinoffset;
-	update_responsibility = update_setup();
-	dma.attachInterrupt(isr);
 #endif
 }
 

--- a/output_mqs.cpp
+++ b/output_mqs.cpp
@@ -66,12 +66,14 @@ void AudioOutputMQS::begin(void)
 	dma.TCD->BITER_ELINKNO = sizeof(I2S3_tx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 	dma.TCD->DADDR = (void *)((uint32_t)&I2S3_TDR0 + 0);
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI3_TX);
 
-	I2S3_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
 	update_responsibility = update_setup();
 	dma.attachInterrupt(isr);
 	dma.enable();
+	
+	I2S3_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
 }
 
 void AudioOutputMQS::isr(void)

--- a/output_pt8211_2.cpp
+++ b/output_pt8211_2.cpp
@@ -71,13 +71,14 @@ void AudioOutputPT8211_2::begin(void)
 	dma.TCD->BITER_ELINKNO = sizeof(i2s_tx_buffer) / 2;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 	dma.TCD->DADDR = (void *)((uint32_t)&I2S2_TDR0);
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_TX);
+	
+	update_responsibility = update_setup();
 	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
-
-	update_responsibility = update_setup();
 }
 
 void AudioOutputPT8211_2::isr(void)

--- a/output_spdif.cpp
+++ b/output_spdif.cpp
@@ -79,13 +79,14 @@ void AudioOutputSPDIF::begin(void)
 	dma.TCD->DLASTSGA = 0;
 	dma.TCD->BITER_ELINKNO = sizeof(SPDIF_tx_buffer) / nbytes_mlno;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_TX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE | I2S_TCSR_FR;
-	dma.attachInterrupt(isr);
-
 #elif defined(__IMXRT1062__)
 	CORE_PIN7_CONFIG  = 3;  //1:TX_DATA0	
 	const int nbytes_mlno = 2 * 4; // 8 Bytes per minor loop
@@ -101,13 +102,15 @@ void AudioOutputSPDIF::begin(void)
 	dma.TCD->DLASTSGA = 0;
 	dma.TCD->BITER_ELINKNO = sizeof(SPDIF_tx_buffer) / nbytes_mlno;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_TX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S1_RCSR |= I2S_RCSR_RE;
 	I2S1_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE | I2S_TCSR_FR;
-	dma.attachInterrupt(isr);
 #endif
 }
 

--- a/output_spdif2.cpp
+++ b/output_spdif2.cpp
@@ -78,12 +78,14 @@ void AudioOutputSPDIF2::begin(void)
 	dma.TCD->DLASTSGA = 0;
 	dma.TCD->BITER_ELINKNO = sizeof(SPDIF_tx_buffer) / nbytes_mlno;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_TX);
+	
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE | I2S_TCSR_FR;
-	dma.attachInterrupt(isr);
 }
 
 /*

--- a/output_spdif3.cpp
+++ b/output_spdif3.cpp
@@ -88,8 +88,8 @@ void AudioOutputSPDIF3::begin(void)
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SPDIF_TX);
 
 	update_responsibility = update_setup();
-	dma.enable();
 	dma.attachInterrupt(isr);
+	dma.enable();
 
 	CORE_PIN14_CONFIG = 3;  //3:SPDIF_OUT
 	SPDIF_SCR |= SPDIF_SCR_DMA_TX_EN;

--- a/output_tdm.cpp
+++ b/output_tdm.cpp
@@ -70,9 +70,11 @@ void AudioOutputTDM::begin(void)
 	dma.TCD->DLASTSGA = 0;
 	dma.TCD->BITER_ELINKNO = sizeof(tdm_tx_buffer) / 4;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_TX);
 
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S0_TCSR = I2S_TCSR_SR;
@@ -91,16 +93,16 @@ void AudioOutputTDM::begin(void)
 	dma.TCD->DLASTSGA = 0;
 	dma.TCD->BITER_ELINKNO = sizeof(tdm_tx_buffer) / 4;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_TX);
 
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	I2S1_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE;
 	I2S1_TCSR = I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
-
 #endif
-	dma.attachInterrupt(isr);
 }
 
 // TODO: needs optimization...

--- a/output_tdm2.cpp
+++ b/output_tdm2.cpp
@@ -66,15 +66,15 @@ void AudioOutputTDM2::begin(void)
 	dma.TCD->DLASTSGA = 0;
 	dma.TCD->BITER_ELINKNO = sizeof(tdm_tx_buffer) / 4;
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI2_TX);
 
 	update_responsibility = update_setup();
+	dma.attachInterrupt(isr);
 	dma.enable();
 
 	//I2S2_RCSR |= I2S_RCSR_RE;
 	I2S2_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE | I2S_TCSR_FRDE;
-
-	dma.attachInterrupt(isr);
 }
 
 // TODO: needs optimization...


### PR DESCRIPTION
As noted on this forum thread, [from about here on](https://forum.pjrc.com/threads/69224-Shematic-for-Teensy-4-1-compatible-Pt8211-Kit?p=307222&viewfull=1#post307222), there can potentially be an issue with poor ordering of initialisation of audio I/O objects. The thread specifically mentioned the PT8211_2 object, and a change "sneaked in" in PR #436 seems to work OK.

I've been through most of the relevant objects and made them consistent, with the best (I believe) ordering being:
- set up hardware and DMA, _without_ enabling them
- take update responsibility
- attach DMA interrupt
- enable DMA
- enable hardware

There's no _obvious_ reason why this should be any worse than the previous cases, what I've managed to test to date suggests nothing is broken, and it _ought_ to serve to reduce instances of audio hardware mysteriously not working occasionally.

One caveat - I haven't managed to implement this for the AudioOutputPWM object, because I don't understand the code! I've PMed the most recent author @MarkTillotson for help.