### PR TITLE
SGTL5000 control: support for multiple I²C busses

### DIFF
--- a/control_sgtl5000.h
+++ b/control_sgtl5000.h
@@ -29,6 +29,7 @@
 
 #include <AudioStream.h>
 #include "AudioControl.h"
+#include "Wire.h"
 
 // SGTL5000-specific defines for headphones
 #define AUDIO_HEADPHONE_DAC 0
@@ -37,8 +38,10 @@
 class AudioControlSGTL5000 : public AudioControl
 {
 public:
-	AudioControlSGTL5000(void) : i2c_addr(0x0A) { }
+	AudioControlSGTL5000(void) : i2c_addr(0x0A), wire{wires[0]} { }
 	void setAddress(uint8_t level);
+	void setWire(uint8_t wnum = 0, uint8_t level = LOW);
+	void setWire(TwoWire& wref = Wire, uint8_t level = LOW);
 	bool enable(void);//For Teensy LC the SGTL acts as master, for all other Teensys as slave.
 	bool enable(const unsigned extMCLK, const uint32_t pllFreq = (4096.0l * AUDIO_SAMPLE_RATE_EXACT) ); //With extMCLK > 0, the SGTL acts as Master
 	bool disable(void) { return false; }
@@ -120,6 +123,8 @@ private:
 	bool semi_automated;
 	void automate(uint8_t dap, uint8_t eq);
 	void automate(uint8_t dap, uint8_t eq, uint8_t filterCount);
+	static TwoWire* wires[3];
+	TwoWire* wire;
 };
 
 //For Filter Type: 0 = LPF, 1 = HPF, 2 = BPF, 3 = NOTCH, 4 = PeakingEQ, 5 = LowShelf, 6 = HighShelf

--- a/gui/index.html
+++ b/gui/index.html
@@ -5170,7 +5170,8 @@ double s_freq = .0625;</p>
 	<h3>Functions</h3>
 	<p>These are the most commonly used SGTL5000 functions.</p>
 	<p class=func><span class=keyword>enable</span>();</p>
-	<p class=desc>Start the SGTL5000.  This function should be called first.
+	<p class=desc>Start the SGTL5000.  This function should be called before any
+	other function, unless setWire() or setAddress() are needed.
 	</p>
 	<p class=func><span class=keyword>volume</span>(level);</p>
 	<p class=desc>Set the headphone volume level.  Range is 0 to 1.0, but
@@ -5185,7 +5186,36 @@ double s_freq = .0625;</p>
 	<p class=desc>When using the microphone input, set the amplifier gain.
 		The input number is in decibels, from 0 to 63.
 	</p>
-
+	
+	<h3>I²C bus configuration</h3>
+	<p>These functions will be of use if you have modified hardware which changes the 
+	I²C address of your audio shield, or have wired it to use a different bus from the 
+	standard Wire one.
+	</p>
+	<p class=func><span class=keyword>setWire</span>(wire,address);</p>
+	<p class=desc>Select the I²C bus and address controlling the SGTL5000.  
+	This function must be called before enable(), if it is used. Default
+	is Wire, LOW address.
+	<br><br>
+	The wire parameter may be a reference to a TwoWire object (Wire, Wire1 etc.) or an integer between
+	0 and 3, which will select from Wire, Wire1, Wire2 and Wire3. If a non-existent selection
+	is attempted then the highest available value will be used.
+	<br><br>
+	The address parameter selects which of the two possible I²C addresses for the 
+	SGTL5000 is in use: 0 will select the "low" address (0x0A), and 1 will select
+	the "high" address (0x2A). 
+	</p>
+	
+	<p class=func><span class=keyword>setAddress</span>(address);</p>
+	<p class=desc>Select the I²C address controlling the SGTL5000.  
+	This function must be called before enable(), if it is used. The library default
+	is LOW address, so if your audio shield is unmodified you won't need this function.
+	<br><br>
+	The address parameter selects which of the two possible I²C addresses for the 
+	SGTL5000 is in use: 0 will select the "low" address (0x0A), and 1 will select
+	the "high" address (0x2A).
+	</p>
+	
 	<h3>Signal Levels</h3>
 
 	<p>The default signal levels should be used for most applications,

--- a/keywords.txt
+++ b/keywords.txt
@@ -137,6 +137,7 @@ trigger	KEYWORD2
 length	KEYWORD2
 threshold	KEYWORD2
 setAddress	KEYWORD2
+setWire	KEYWORD2
 enable	KEYWORD2
 enableIn	KEYWORD2
 enableOut	KEYWORD2


### PR DESCRIPTION
This PR adds a setWire() function to the AudioControlSGTL5000 class, allowing any available I²C bus to be selected to control an SGTL5000 audio shield. Either a reference to an existing TwoWire object or integer index based selection is supported; if the latter is used, then 0-3 map to Wire, Wire1, Wire2 and Wire3.

The GUI design tool documentation and keywords.txt have also been updated.