### PR TITLE
Fix minor issue with AudioEffectEnvelope::release

### DIFF
--- a/effect_envelope.cpp
+++ b/effect_envelope.cpp
@@ -78,7 +78,7 @@ void AudioEffectEnvelope::update(void)
 	block = receiveWritable();
 	if (!block) return;
 	if (state == STATE_IDLE) {
-		release(block);
+		AudioStream::release(block);
 		return;
 	}
 	p = (uint32_t *)(block->data);
@@ -177,7 +177,7 @@ void AudioEffectEnvelope::update(void)
 		count--;
 	}
 	transmit(block);
-	release(block);
+	AudioStream::release(block);
 }
 
 bool AudioEffectEnvelope::isActive()

--- a/effect_envelope.h
+++ b/effect_envelope.h
@@ -76,7 +76,6 @@ public:
 	}
 	bool isActive();
 	bool isSustain();
-	using AudioStream::release;
 	virtual void update(void);
 private:
 	uint16_t milliseconds2count(float milliseconds) {


### PR DESCRIPTION
As discussed in forum thread https://forum.pjrc.com/threads/70856-Error-Using-Audio-Library-Envelope-Object, calling AudioEffectEnvelope::release() with a zero parameter gave a compiler error, because it could be a call to AudioStream::release() with a NULL buffer pointer. Ideally the user should of course follow the documentation and only pass a float parameter to AudioEffectEnvelope::release() ... but we don't live in an ideal world, do we?

Attached .txt file is actually a .ino (which github refuses to allow...): throws a compile error at line 49 with the old library, and works as intended with this change applied.

[TestEnvelope.txt](https://github.com/PaulStoffregen/Audio/files/9311260/TestEnvelope.txt)
