### PR TITLE
Make AudioPlaySdWav object honour the value of AUDIO_BLOCK_SAMPLES

### DIFF
--- a/play_sd_raw.cpp
+++ b/play_sd_raw.cpp
@@ -96,7 +96,7 @@ void AudioPlaySdRaw::update(void)
 
 	if (rawfile.available()) {
 		// we can read more data from the file...
-		n = rawfile.read(block->data, AUDIO_BLOCK_SAMPLES*2);
+		n = rawfile.read(block->data, AUDIO_BLOCK_SAMPLES*sizeof(int16_t));
 		file_offset += n;
 		for (i=n/2; i < AUDIO_BLOCK_SAMPLES; i++) {
 			block->data[i] = 0;

--- a/play_sd_wav.cpp
+++ b/play_sd_wav.cpp
@@ -167,11 +167,11 @@ void AudioPlaySdWav::update(void)
 		if (consume(n)) return; // it was enough to transmit audio
 	}
 
-	// we only get to this point when buffer[512] is empty
+	// we only get to this point when buffer[] is empty
 	if (state != STATE_STOP && wavfile.available()) {
 		// we can read more data from the file...
 		readagain:
-		buffer_length = wavfile.read(buffer, 512);
+		buffer_length = wavfile.read(buffer, sizeof buffer);
 		if (buffer_length == 0) goto end;
 		buffer_offset = 0;
 		bool parsing = (state >= 8);

--- a/play_sd_wav.h
+++ b/play_sd_wav.h
@@ -31,6 +31,16 @@
 #include "AudioStream.h"
 #include "SD.h"
 
+// Need to buffer at least two audio blocks of samples, for stereo files,
+// but if AUDIO_BLOCK_SAMPLES has been set to a small value (<128 samples)
+// then it's better to buffer 2*128 samples, which happens to be an SD
+// card sector.
+#if AUDIO_BLOCK_SAMPLES < 128
+	#define BUFFER_BYTES 2*128*sizeof(int16_t)
+#else
+	#define BUFFER_BYTES 2*AUDIO_BLOCK_SAMPLES*sizeof(int16_t)
+#endif // AUDIO_BLOCK_SAMPLES < 128
+
 class AudioPlaySdWav : public AudioStream
 {
 public:
@@ -56,7 +66,7 @@ private:
 	audio_block_t *block_left;
 	audio_block_t *block_right;
 	uint16_t block_offset;		// how much data is in block_left & block_right
-	uint8_t buffer[512];		// buffer one block of data
+	uint8_t buffer[BUFFER_BYTES];	// buffer at least two audio blocks of data
 	uint16_t buffer_offset;		// where we're at consuming "buffer"
 	uint16_t buffer_length;		// how much data is in "buffer" (512 until last read)
 	uint8_t header_offset;		// number of bytes in header[]


### PR DESCRIPTION
Loads either one SD card sector / 512 bytes, or two blocks' worth (to allow for stereo playback) if AUDIO_BLOCK_SAMPLES is set to >128. Minor change to play_sd_raw.cpp to remove magic number.

Very simple update, no (intentional!) change in behaviour with standard library settings.