### PR TITLE
Play_raw Play_wav to any FS

### DIFF
--- a/play_sd_raw.cpp
+++ b/play_sd_raw.cpp
@@ -37,8 +37,9 @@ void AudioPlaySdRaw::begin(void)
 }
 
 
-bool AudioPlaySdRaw::play(const char *filename)
+bool AudioPlaySdRaw::play(const char *filename, FS *pfs)
 {
+	if (!pfs) return false;
 	stop();
 #if defined(HAS_KINETIS_SDHC)
 	if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStartUsingSPI();
@@ -46,7 +47,7 @@ bool AudioPlaySdRaw::play(const char *filename)
 	AudioStartUsingSPI();
 #endif
 	__disable_irq();
-	rawfile = SD.open(filename);
+	rawfile = pfs->open(filename);
 	__enable_irq();
 	if (!rawfile) {
 		//Serial.println("unable to open file");

--- a/play_sd_raw.h
+++ b/play_sd_raw.h
@@ -36,7 +36,7 @@ class AudioPlaySdRaw : public AudioStream
 public:
 	AudioPlaySdRaw(void) : AudioStream(0, NULL) { begin(); }
 	void begin(void);
-	bool play(const char *filename);
+	bool play(const char *filename, FS *pfs=&SD);
 	void stop(void);
 	bool isPlaying(void) { return playing; }
 	uint32_t positionMillis(void);

--- a/play_sd_wav.cpp
+++ b/play_sd_wav.cpp
@@ -61,8 +61,9 @@ void AudioPlaySdWav::begin(void)
 }
 
 
-bool AudioPlaySdWav::play(const char *filename)
+bool AudioPlaySdWav::play(const char *filename, FS *pfs)
 {
+	if (!pfs) return false;
 	stop();
 	bool irq = false;
 	if (NVIC_IS_ENABLED(IRQ_SOFTWARE)) {
@@ -74,7 +75,7 @@ bool AudioPlaySdWav::play(const char *filename)
 #else
 	AudioStartUsingSPI();
 #endif
-	wavfile = SD.open(filename);
+	wavfile = pfs->open(filename);
 	if (!wavfile) {
 #if defined(HAS_KINETIS_SDHC)
 		if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();

--- a/play_sd_wav.h
+++ b/play_sd_wav.h
@@ -36,7 +36,7 @@ class AudioPlaySdWav : public AudioStream
 public:
 	AudioPlaySdWav(void) : AudioStream(0, NULL), block_left(NULL), block_right(NULL) { begin(); }
 	void begin(void);
-	bool play(const char *filename);
+	bool play(const char *filename, FS *pfs=&SD);
 	void togglePlayPause(void);
 	void stop(void);
 	bool isPlaying(void);


### PR DESCRIPTION
@PaulStoffregen @mjs513 @h4yn0nnym0u5e

This is an alternate implementation of
#419

As mentioned in the forum thread: https://forum.pjrc.com/threads/71716-recording-playing-back-audio-on-multiple-SD-cards

It simply adds optional parameter at the end of the play method for the FS which defaults to SD

The other PR, makes a copy of the play method and adds the FS as the first parameter.

Either way works for me.
