### PR TITLE
Fix stuck AudioEffectFade

### DIFF
--- a/effect_fade.cpp
+++ b/effect_fade.cpp
@@ -35,9 +35,7 @@ extern const int16_t fader_table[257];
 void AudioEffectFade::update(void)
 {
 	audio_block_t *block;
-	uint32_t i, pos, inc, index, scale;
-	int32_t val1, val2, val, sample;
-	uint8_t dir;
+	uint32_t pos;
 
 	pos = position;
 	if (pos == 0) {
@@ -45,7 +43,7 @@ void AudioEffectFade::update(void)
 		block = receiveReadOnly();
 		if (block) release(block);
 		return;
-	} else if (pos == 0xFFFFFFFF) {
+	} else if (pos == MAX_FADE) {
 		// output is 100%
 		block = receiveReadOnly();
 		if (!block) return;
@@ -53,42 +51,64 @@ void AudioEffectFade::update(void)
 		release(block);
 		return;
 	}
+	
 	block = receiveWritable();
-	if (!block) return;
-	inc = rate;
-	dir = direction;
-	for (i=0; i < AUDIO_BLOCK_SAMPLES; i++) {
-		index = pos >> 24;
-		val1 = fader_table[index];
-		val2 = fader_table[index+1];
-		scale = (pos >> 8) & 0xFFFF;
-		val2 *= scale;
-		val1 *= 0x10000 - scale;
-		val = (val1 + val2) >> 16;
-		sample = block->data[i];
-		sample = (sample * val) >> 15;
-		block->data[i] = sample;
-		if (dir > 0) {
-			// output is increasing
-			if (inc < 0xFFFFFFFF - pos) pos += inc;
-			else pos = 0xFFFFFFFF;
-		} else {
-			// output is decreasing
-			if (inc < pos) pos -= inc;
-			else pos = 0;
+	if (block)
+	{
+		uint32_t inc = rate;
+		uint8_t dir = direction;
+		for (uint32_t i=0; i < AUDIO_BLOCK_SAMPLES; i++) 
+		{
+			int32_t val1, val2, val, sample;
+			uint32_t index = pos >> 24;
+			val1 = fader_table[index];
+			val2 = fader_table[index+1];
+			uint32_t scale = (pos >> 8) & 0xFFFF;
+			val2 *= scale;
+			val1 *= 0x10000 - scale;
+			val = (val1 + val2) >> 16;
+			sample = block->data[i];
+			sample = (sample * val) >> 15;
+			block->data[i] = sample;
+			if (dir > 0) {
+				// output is increasing
+				if (inc < MAX_FADE - pos) pos += inc;
+				else pos = MAX_FADE;
+			} else {
+				// output is decreasing
+				if (inc < pos) pos -= inc;
+				else pos = 0;
+			}
 		}
+		position = pos;
+		transmit(block);
+		release(block);
 	}
-	position = pos;
-	transmit(block);
-	release(block);
+	else // no audio, but must still change fader position!
+	{
+		int64_t newPos = (int64_t) rate * AUDIO_BLOCK_SAMPLES;
+		if (direction <= 0) // change is downwards
+			newPos = (int64_t) position - newPos;
+		else
+			newPos = (int64_t) position + newPos;
+		
+		if (newPos <= 0LL) 			position = 0;
+		else if (newPos > MAX_FADE) position = MAX_FADE;
+		else 						position = newPos;
+	}
 }
 
-void AudioEffectFade::fadeBegin(uint32_t newrate, uint8_t dir)
+void AudioEffectFade::fadeBegin(uint32_t samples, uint8_t dir)
 {
 	__disable_irq();
+	if (0 == samples) samples = 1; // avoid divide-by-zero error
+	uint32_t newrate = MAX_FADE / samples; // worst case is 1: takes 27 hours...
 	uint32_t pos = position;
-	if (pos == 0) position = 1;
-	else if (pos == 0xFFFFFFFF) position = 0xFFFFFFFE;
+	
+	// fader sticks at ends, so ensure it runs if needed
+	if (pos == 0 && dir > 0) 			  position = 1;
+	else if (pos == MAX_FADE && dir <= 0) position = MAX_FADE - 1;
+	
 	rate = newrate;
 	direction = dir;
 	__enable_irq();

--- a/effect_fade.h
+++ b/effect_fade.h
@@ -32,23 +32,24 @@
 
 class AudioEffectFade : public AudioStream
 {
+	const uint32_t MAX_FADE = 0xFFFFFFFFu; // fader fully up - pass through
 public:
 	AudioEffectFade(void)
-	  : AudioStream(1, inputQueueArray), position(0xFFFFFFFF) {}
+	  : AudioStream(1, inputQueueArray), position(MAX_FADE) {}
 	void fadeIn(uint32_t milliseconds) {
 		uint32_t samples = (uint32_t)(milliseconds * 441u + 5u) / 10u;
 		//Serial.printf("fadeIn, %u samples\n", samples);
-		fadeBegin(0xFFFFFFFFu / samples, 1);
+		fadeBegin(samples, 1);
 	}
 	void fadeOut(uint32_t milliseconds) {
 		uint32_t samples = (uint32_t)(milliseconds * 441u + 5u) / 10u;
 		//Serial.printf("fadeOut, %u samples\n", samples);
-		fadeBegin(0xFFFFFFFFu / samples, 0);
+		fadeBegin(samples, 0);
 	}
 	virtual void update(void);
 private:
-	void fadeBegin(uint32_t newrate, uint8_t dir);
-	uint32_t position; // 0 = off, 0xFFFFFFFF = on
+	void fadeBegin(uint32_t samples, uint8_t dir);
+	uint32_t position; // 0 = off, MAX_FADE = on
 	uint32_t rate;
 	uint8_t direction; // 0 = fading out, 1 = fading in
 	audio_block_t *inputQueueArray[1];

--- a/effect_fade.h
+++ b/effect_fade.h
@@ -33,16 +33,17 @@
 class AudioEffectFade : public AudioStream
 {
 	const uint32_t MAX_FADE = 0xFFFFFFFFu; // fader fully up - pass through
+	const uint32_t MILLIS_MULT = (int) (AUDIO_SAMPLE_RATE_EXACT) / 100;
 public:
 	AudioEffectFade(void)
 	  : AudioStream(1, inputQueueArray), position(MAX_FADE) {}
 	void fadeIn(uint32_t milliseconds) {
-		uint32_t samples = (uint32_t)(milliseconds * 441u + 5u) / 10u;
+		uint32_t samples = (uint32_t)(milliseconds * MILLIS_MULT + 5u) / 10u;
 		//Serial.printf("fadeIn, %u samples\n", samples);
 		fadeBegin(samples, 1);
 	}
 	void fadeOut(uint32_t milliseconds) {
-		uint32_t samples = (uint32_t)(milliseconds * 441u + 5u) / 10u;
+		uint32_t samples = (uint32_t)(milliseconds * MILLIS_MULT + 5u) / 10u;
 		//Serial.printf("fadeOut, %u samples\n", samples);
 		fadeBegin(samples, 0);
 	}


### PR DESCRIPTION
Another instance of an audio object which did nothing when a NULL block arrives, even when internal state is time-dependent...

This fix keeps the fade process going even if NULL audio blocks are passed in, so you can e.g. preset a fade to a known value _before_ starting its input. Also traps a potential divide-by-zero error if a fade of 0.0 milliseconds is requested.