### PR TITLE
sgtl5000: headphoneSelect correct bits

### DIFF
--- a/control_sgtl5000.h
+++ b/control_sgtl5000.h
@@ -62,9 +62,9 @@ public:
 	}
 	bool headphoneSelect(int n) {
 		if (n == AUDIO_HEADPHONE_DAC) {
-			return write(0x0024, ana_ctrl | (1<<6)); // route DAC to headphones out
-		} else if (n == AUDIO_HEADPHONE_LINEIN) {
 			return write(0x0024, ana_ctrl & ~(1<<6)); // route linein to headphones out
+		} else if (n == AUDIO_HEADPHONE_LINEIN) {
+			return write(0x0024, ana_ctrl | (1<<6)); // route DAC to headphones out
 		} else {
 			return false;
 		}


### PR DESCRIPTION
Fixes `headphoneSelect`: we are currently writing 1 to select DAC and 0 to select LINEIN.
However, SGTL5000 datasheet (page 39) says the opposite:

    Select the headphone input.
    0x0 = DAC
    0x1 = LINEIN

And in fact I observe the wrong behavior: I get LINEIN out when calling `headphoneSelect(AUDIO_HEADPHONES_DAC)`, and DAC out when calling `heaphoneSelect(AUDIO_HEADPHONES_LINEIN)`. This PR fixes it.
