### PR TITLE
Fix output_tdm2 excessive copy

### DIFF
--- a/output_adat.cpp
+++ b/output_adat.cpp
@@ -125,8 +125,8 @@ void AudioOutputADAT::isr(void)
 	const int16_t *src1, *src2, *src3, *src4,*src5, *src6, *src7, *src8;
 	const int16_t *zeros = (const int16_t *)zerodata;
 
-	uint32_t *end, *dest, *toFlush;
-	uint32_t saddr, flushLen;
+	uint32_t *end, *dest;
+	uint32_t saddr;
 	uint32_t sample1, sample2, sample3, sample4, sample5, sample6, sample7, sample8;
 
 	static uint32_t previousnrzi_highlow = 0; //this is used for the NZRI encoding to remember the last state.
@@ -148,8 +148,10 @@ void AudioOutputADAT::isr(void)
 		dest = (uint32_t *)ADAT_tx_buffer;
 		end = (uint32_t *)&ADAT_tx_buffer[AUDIO_BLOCK_SAMPLES * 8/2];
 	}
-	toFlush = dest;
-	flushLen = sizeof ADAT_tx_buffer / 2;
+#if IMXRT_CACHE_ENABLED >= 2
+	uint32_t *toFlush = dest;
+	uint32_t flushLen = sizeof ADAT_tx_buffer / 2;
+#endif
 
 	src1 = (block_ch1_1st) ? block_ch1_1st->data + ch1_offset : zeros;
 	src2 = (block_ch2_1st) ? block_ch2_1st->data + ch2_offset : zeros;

--- a/output_tdm2.cpp
+++ b/output_tdm2.cpp
@@ -82,7 +82,7 @@ static void memcpy_tdm_tx(uint32_t *dest, const uint32_t *src1, const uint32_t *
 {
 	uint32_t i, in1, in2, out1, out2;
 
-	for (i=0; i < AUDIO_BLOCK_SAMPLES/2; i++) {
+	for (i=0; i < AUDIO_BLOCK_SAMPLES/4; i++) {
 
 		in1 = *src1++;
 		in2 = *src2++;

--- a/output_tdm2.cpp
+++ b/output_tdm2.cpp
@@ -49,7 +49,11 @@ void AudioOutputTDM2::begin(void)
 	for (int i=0; i < 16; i++) {
 		block_input[i] = nullptr;
 	}
-
+	
+	// DMAMEM doesn't get zeroed, have to do it ourselves:
+	memset(zeros, 0, sizeof zeros);
+	memset(tdm_tx_buffer, 0, sizeof tdm_tx_buffer);
+	
 	// TODO: should we set & clear the I2S_TCSR_SR bit here?
 	config_tdm();
 


### PR DESCRIPTION
`memcpy_tdm_tx()` waas copying twice as much data as it should, overflowing the output buffer. Now does the same as `output_tdm`, which appears to be correct.