### PR TITLE
prevent page reloads when pressing enter while changing node names

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -148,7 +148,7 @@ span.mainfunction {color: #993300; font-weight: bolder}
 <div id="notifications"></div>
 <div id="dropTarget"><div>Drop the flow here</div></div>
 
-<div id="dialog" class="hide"><form id="dialog-form" class="form-horizontal"></form></div>
+<div id="dialog" class="hide"><form id="dialog-form" class="form-horizontal" onsubmit="return false"></form></div>
 <div id="node-config-dialog" class="hide"><form id="dialog-config-form" class="form-horizontal"></form><div class="form-tips" id="node-config-dialog-user-count"></div></div>
 
 <div id="node-dialog-confirm-deploy" class="hide">


### PR DESCRIPTION
Pressing the enter key while changing the name of a node in the Audio System Design Tool causes a page reload. This small fix prevents the page reload.