### PR TITLE
class member variable compatible export format

### DIFF
--- a/gui/red/main.js
+++ b/gui/red/main.js
@@ -91,7 +91,7 @@ var RED = (function() {
 							if (wire) {
 								var parts = wire.split(":");
 								if (parts.length == 2) {
-									cpp += "AudioConnection          patchCord" + cordcount + "(";
+									cpp += "AudioConnection          patchCord" + cordcount + " = AudioConnection(";
 									var src = RED.nodes.node(n.id);
 									var dst = RED.nodes.node(parts[0]);
 									var src_name = make_name(src);


### PR DESCRIPTION
The current export format of the Audio System Design Tool cannot be used for class member variables. Changing the format slightly allows it to be used both as class member variables and as globals. The changed format is still compatible with the import.