### PR TITLE
added method for restarting the phase accumulator

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -3341,6 +3341,14 @@ The actual packets are taken
 		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
 		should be used to guarantee all new settings take effect together.
 	</p>
+	<p class=func><span class=keyword>restart</span>();</p>
+	<p class=desc>
+		Cause the generated waveform to restart its cycle. The generation
+		starts with the angle 0 degrees (default) or with the last value
+		configured by phase(angle);. When multiple objects are configured,
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
+		should be used to guarantee all new settings take effect together.
+	</p>
 	<p class=func><span class=keyword>pulseWidth</span>(amount);</p>
 	<p class=desc>Change the width (duty cycle) of the pulse.</p>
 	<p class=func><span class=keyword>arbitraryWaveform</span>(array, maxFreq);</p>
@@ -3412,6 +3420,14 @@ The actual packets are taken
 	</p>
 	<p class=func><span class=keyword>amplitude</span>(level);</p>
 	<p class=desc>Change the amplitude.  Set to 0 to turn the signal off.
+	</p>
+	<p class=func><span class=keyword>restart</span>();</p>
+	<p class=desc>
+		Cause the generated waveform to restart its cycle. The generation
+		starts with the angle 0 degrees (default) or with the last value
+		configured by phase(angle);. When multiple objects are configured,
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
+		should be used to guarantee all new settings take effect together.
 	</p>
 	<p class=func><span class=keyword>offset</span>(level);</p>
 	<p class=desc>Add a DC offset, from -1.0 to +1.0.  Useful for generating

--- a/synth_waveform.cpp
+++ b/synth_waveform.cpp
@@ -45,6 +45,12 @@ void AudioSynthWaveform::update(void)
 	uint32_t i, ph, index, index2, scale;
 	const uint32_t inc = phase_increment;
 
+	// Restart the phase accumulator if requested using restart()
+	if (restart_phase_accumulator) {
+		phase_accumulator = 0;
+		restart_phase_accumulator = false;
+	}
+
 	ph = phase_accumulator + phase_offset;
 	if (magnitude == 0) {
 		phase_accumulator += inc * AUDIO_BLOCK_SAMPLES;
@@ -234,6 +240,12 @@ void AudioSynthWaveformModulated::update(void)
 
 	moddata = receiveReadOnly(0);
 	shapedata = receiveReadOnly(1);
+
+	// Restart the phase accumulator if requested using restart()
+	if (restart_phase_accumulator) {
+		phase_accumulator = 0;
+		restart_phase_accumulator = false;
+	}
 
 	// Pre-compute the phase angle for every output sample of this update
 	ph = phase_accumulator;

--- a/synth_waveform.h
+++ b/synth_waveform.h
@@ -101,7 +101,7 @@ public:
 		phase_accumulator(0), phase_increment(0), phase_offset(0),
 		magnitude(0), pulse_width(0x40000000),
 		arbdata(NULL), sample(0), tone_type(WAVEFORM_SINE),
-		tone_offset(0) {
+		tone_offset(0), restart_phase_accumulator(false) {
 	}
 
 	void frequency(float freq) {
@@ -121,6 +121,9 @@ public:
 			if (angle >= 360.0f) return;
 		}
 		phase_offset = angle * (float)(4294967296.0 / 360.0);
+	}
+	void restart() {
+		restart_phase_accumulator = true;
 	}
 	void amplitude(float n) {	// 0 to 1.0
 		if (n < 0) {
@@ -178,6 +181,7 @@ private:
 	short    tone_type;
 	int16_t  tone_offset;
         BandLimitedWaveform band_limit_waveform ;
+	bool     restart_phase_accumulator;
 };
 
 
@@ -187,7 +191,7 @@ public:
 	AudioSynthWaveformModulated(void) : AudioStream(2, inputQueueArray),
 		phase_accumulator(0), phase_increment(0), modulation_factor(32768),
 		magnitude(0), arbdata(NULL), sample(0), tone_offset(0),
-		tone_type(WAVEFORM_SINE), modulation_type(0) {
+		tone_type(WAVEFORM_SINE), modulation_type(0), restart_phase_accumulator(false) {
 	}
 
 	void frequency(float freq) {
@@ -198,6 +202,9 @@ public:
 		}
 		phase_increment = freq * (4294967296.0f / AUDIO_SAMPLE_RATE_EXACT);
 		if (phase_increment > 0x7FFE0000u) phase_increment = 0x7FFE0000;
+	}
+	void restart() {
+		restart_phase_accumulator = true;
 	}
 	void amplitude(float n) {	// 0 to 1.0
 		if (n < 0) {
@@ -265,6 +272,7 @@ private:
 	uint8_t  tone_type;
 	uint8_t  modulation_type;
         BandLimitedWaveform band_limit_waveform ;
+	bool     restart_phase_accumulator;
 };
 
 


### PR DESCRIPTION
Added a method restart() to AudioSynthWaveform and AudioSynthWaveformModulated to reset the phase_accumulator to 0. This allows the phase of multiple oscillators in a synthesizer to be synchronized upon note on.