### PR TITLE
Fix odd channel sample swap for TDM inputs

### DIFF
--- a/input_tdm.cpp
+++ b/input_tdm.cpp
@@ -99,7 +99,7 @@ static void memcpy_tdm_rx(uint32_t *dest1, uint32_t *dest2, const uint32_t *src)
 		in2 = *(src+8);
 		src += 16;
 		*dest1++ = (in1 >> 16) | (in2 & 0xFFFF0000);
-		*dest2++ = (in1 << 16) | (in2 & 0x0000FFFF);
+		*dest2++ = (in1 & 0x0000FFFF)  | (in2 << 16);
 	}
 }
 

--- a/input_tdm2.cpp
+++ b/input_tdm2.cpp
@@ -80,7 +80,7 @@ static void memcpy_tdm_rx(uint32_t *dest1, uint32_t *dest2, const uint32_t *src)
 		in2 = *(src+8);
 		src += 16;
 		*dest1++ = (in1 >> 16) | (in2 & 0xFFFF0000);
-		*dest2++ = (in1 << 16) | (in2 & 0x0000FFFF);
+		*dest2++ = (in1 & 0x0000FFFF)  | (in2 << 16);
 	}
 }
 


### PR DESCRIPTION
In the existing code, the samples for odd channels are swapped when being transferred from the DMA buffer to the audio buffer.

dest1 is correctly calculated, however the early sample for dest2 goes into the high part of 32-bit *dest2, and the later sample goes into the low part.

This is not obvious for 32-bit TDM slots as the advice is to ignore odd TDM inputs. For 16 bit slots it results in corruption - see Issue 479 [https://github.com/PaulStoffregen/Audio/issues/479](url)
```
*dest1++ = (in1 >> 16) | (in2 & 0xFFFF0000);
*dest2++ = (in1 << 16) | (in2 & 0x0000FFFF);
```
the correct code is 
```
*dest1++ = (in1 >> 16) | (in2 & 0xFFFF0000);
*dest2++ = (in1 & 0x0000FFFF)  | (in2 << 16);	
```	
The changed code has been tested on both CS42448 and TLV320AIC3104 hardware in TDM mode.
