### PR TITLE
Use nested interrupts (NVIC) in play_sd_raw.cpp

### DIFF
--- a/play_sd_raw.cpp
+++ b/play_sd_raw.cpp
@@ -40,14 +40,17 @@ void AudioPlaySdRaw::begin(void)
 bool AudioPlaySdRaw::play(const char *filename)
 {
 	stop();
+	bool irq = false;
+	if (NVIC_IS_ENABLED(IRQ_SOFTWARE)) {
+		NVIC_DISABLE_IRQ(IRQ_SOFTWARE);
+		irq = true;
+	}
 #if defined(HAS_KINETIS_SDHC)
 	if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStartUsingSPI();
 #else
 	AudioStartUsingSPI();
 #endif
-	__disable_irq();
 	rawfile = SD.open(filename);
-	__enable_irq();
 	if (!rawfile) {
 		//Serial.println("unable to open file");
 		#if defined(HAS_KINETIS_SDHC)
@@ -55,8 +58,10 @@ bool AudioPlaySdRaw::play(const char *filename)
 		#else
 			AudioStopUsingSPI();
 		#endif
+		if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
 		return false;
 	}
+	if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
 	file_size = rawfile.size();
 	file_offset = 0;
 	//Serial.println("able to open file");
@@ -66,21 +71,22 @@ bool AudioPlaySdRaw::play(const char *filename)
 
 void AudioPlaySdRaw::stop(void)
 {
-	__disable_irq();
+	bool irq = false;
+	if (NVIC_IS_ENABLED(IRQ_SOFTWARE)) {
+		NVIC_DISABLE_IRQ(IRQ_SOFTWARE);
+		irq = true;
+	}
 	if (playing) {
 		playing = false;
-		__enable_irq();
 		rawfile.close();
 		#if defined(HAS_KINETIS_SDHC)
 			if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
 		#else
 			AudioStopUsingSPI();
 		#endif
-	} else {
-		__enable_irq();
 	}
+	if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
 }
-
 
 void AudioPlaySdRaw::update(void)
 {


### PR DESCRIPTION
This copies over the changes that were made in 6369a6ae1f3b6ea547a5192f9bf7efe3b778a629 to fix the same issue for raw audio files. The issues are also discussed in this forum post: https://forum.pjrc.com/index.php?threads/teensy-4-0-first-beta-test.54711/page-127#post-207700

Before this change, playing a second raw file while one was already playing would result in inconsistent behaviour. I observed it doing one of three things:
- it would work as desired ~30% of the time
- freeze all code execution ~50% of the time
- freeze for 1-5 seconds, not play the second file, and return, resuming code immediately after the call to `AudioPlaySdRaw.play`