### PR TITLE
Create reader to FFT outputflag (available) without resetting value

### DIFF
--- a/analyze_fft1024.h
+++ b/analyze_fft1024.h
@@ -60,6 +60,9 @@ public:
 		}
 		return false;
 	}
+	bool peekAvailable() {
+		return outputflag;
+	}
 	float read(unsigned int binNumber) {
 		if (binNumber > 511) return 0.0;
 		return (float)(output[binNumber]) * (1.0f / 16384.0f);

--- a/analyze_fft256.h
+++ b/analyze_fft256.h
@@ -68,6 +68,9 @@ public:
 		}
 		return false;
 	}
+	bool peekAvailable() {
+		return outputflag;
+	}
 	float read(unsigned int binNumber) {
 		if (binNumber > 127) return 0.0;
 		return (float)(output[binNumber]) * (1.0f / 16384.0f);


### PR DESCRIPTION
This creates a method, `peekAvailable()`, for reading the value of `outputflag` in the AudioAnalyzeFFT256 and AudioAnalyzeFFT1024 classes. The current method, `available()`, resets the value to false after reading.

In some usage, it's inconvenient to read the value and reset it, requiring the user to keep the value around for later use.